### PR TITLE
Refactor Streamlit app to use core parsing modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,22 @@ once the executable is launched. The resulting binary will appear in the
 The `normalize_price` helper converts textual prices into numeric values. By
 default it assumes European formatting (e.g. `1.234,56`). Pass
 `style="en"` to handle English formatted numbers such as `1,234.56`.
+
+### CLI usage
+
+Extract prices from files on the command line and save the merged result:
+
+```bash
+python price_parser.py data/list.xlsx another.pdf -o merged_prices.xlsx
+```
+
+### Running the Streamlit interface
+
+Launch the web UI locally with:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+From the interface you can upload Excel/PDF price lists and search the
+resulting master dataset.

--- a/core/extract_excel.py
+++ b/core/extract_excel.py
@@ -12,6 +12,9 @@ POSSIBLE_CODE_HEADERS = [
 POSSIBLE_DESC_HEADERS = [
     'ürün adı', 'malzeme adı', 'product name', 'item name', 'description'
 ]
+
+# Combined list used by the PDF extractor
+POSSIBLE_PRODUCT_NAME_HEADERS = POSSIBLE_CODE_HEADERS + POSSIBLE_DESC_HEADERS
 POSSIBLE_PRICE_HEADERS = [
     'fiyat', 'birim fiyat', 'liste fiyatı', 'price', 'unit price', 'list price',
     'tutar'


### PR DESCRIPTION
## Summary
- reuse `extract_from_excel` and `extract_from_pdf` in the Streamlit interface
- expose `POSSIBLE_PRODUCT_NAME_HEADERS` for PDF extraction
- document CLI and Streamlit usage

## Testing
- `pytest -q`