### PR TITLE
Fix pip install packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "openpyxl",
 ]
 
+[tool.setuptools]
+packages = ["core"]
+py-modules = ["price_parser", "streamlit_app"]
+
 [project.scripts]
 smart-price-parser = "price_parser:main"
 smart-price-app = "streamlit_app:cli"


### PR DESCRIPTION
## Summary
- specify core package and modules in `pyproject.toml`

## Testing
- `pytest -q`
- `pip install .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*