### PR TITLE
Fix BytesIO inputs

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -28,14 +28,18 @@ def get_master_dataset_path() -> str:
     return DATA_FILE
 
 
-def extract_from_excel_file(file: io.BytesIO) -> pd.DataFrame:
+def extract_from_excel_file(
+    file: io.BytesIO, *, file_name: str | None = None
+) -> pd.DataFrame:
     """Wrapper around :func:`core.extract_excel.extract_from_excel`."""
-    return extract_from_excel(file)
+    return extract_from_excel(file, filename=file_name)
 
 
-def extract_from_pdf_file(file: io.BytesIO) -> pd.DataFrame:
+def extract_from_pdf_file(
+    file: io.BytesIO, *, file_name: str | None = None
+) -> pd.DataFrame:
     """Wrapper around :func:`core.extract_pdf.extract_from_pdf`."""
-    return extract_from_pdf(file)
+    return extract_from_pdf(file, filename=file_name)
 
 
 def merge_files(uploaded_files):
@@ -44,9 +48,9 @@ def merge_files(uploaded_files):
         name = up_file.name.lower()
         bytes_data = io.BytesIO(up_file.read())
         if name.endswith((".xlsx", ".xls")):
-            df = extract_from_excel_file(bytes_data)
+            df = extract_from_excel_file(bytes_data, file_name=up_file.name)
         elif name.endswith(".pdf"):
-            df = extract_from_pdf_file(bytes_data)
+            df = extract_from_pdf_file(bytes_data, file_name=up_file.name)
         else:
             continue
         if not df.empty:

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -44,6 +44,25 @@ def test_extract_from_excel_basic(tmp_path):
     assert result.iloc[0]["Fiyat"] == 1000.50
     assert result.iloc[1]["Fiyat"] == 2500.75
 
+
+def test_extract_from_excel_bytesio():
+    if not HAS_PANDAS:
+        pytest.skip("pandas not installed")
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+    import io
+
+    data = {"Ürün Adı": ["Elma", "Armut"], "Fiyat": ["1.000,50", "2.500,75"]}
+    df = pd.DataFrame(data)
+    buffer = io.BytesIO()
+    df.to_excel(buffer, index=False)
+    buffer.seek(0)
+
+    result = extract_from_excel(buffer, filename="sample.xlsx")
+    assert len(result) == 2
+    assert result.iloc[0]["Fiyat"] == 1000.50
+    assert result.iloc[1]["Fiyat"] == 2500.75
+
 def test_normalize_price_various_formats():
     assert normalize_price("1.234,56") == 1234.56
     assert normalize_price("1,234.56", style="en") == 1234.56


### PR DESCRIPTION
## Summary
- allow BytesIO inputs in `extract_from_pdf` and `extract_from_excel`
- pass filenames from Streamlit to extractors
- test Excel extraction with BytesIO

## Testing
- `pytest -q`