### PR TITLE
Improve brand detection from file names

### DIFF
--- a/core/common_utils.py
+++ b/core/common_utils.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import Optional
 
@@ -78,20 +79,31 @@ def select_latest_year_column(df, pattern: str = r"(\d{4})") -> Optional[str]:
     return max(year_cols, key=year_cols.get)
 
 
-def detect_brand(description: str) -> Optional[str]:
-    """Very naive brand detection placeholder.
+def detect_brand(text: str) -> Optional[str]:
+    """Try to infer brand name from a file name.
+
+    The function is intentionally simple. If ``text`` looks like a file
+    path, the first textual token in the base name (without extension) is
+    returned. Otherwise ``None`` is yielded.
 
     Parameters
     ----------
-    description : str
-        Product description to analyse.
+    text : str
+        File path or name that potentially encodes the brand name.
 
     Returns
     -------
     str or None
-        Detected brand name if any. Currently this implementation only returns
-        ``None`` and exists as a hook for future improvements.
+        Detected brand name if any, otherwise ``None``.
     """
-    if not description:
+    if not text:
         return None
+
+    base = os.path.basename(str(text))
+    match = re.search(r"\.([A-Za-z0-9]{2,4})$", base)
+    if match:
+        base = os.path.splitext(base)[0]
+        for token in re.split(r"[\s_-]+", base):
+            if re.search(r"[A-Za-z]", token):
+                return token
     return None

--- a/core/extract_excel.py
+++ b/core/extract_excel.py
@@ -111,11 +111,15 @@ def extract_from_excel(
                 if "Para_Birimi" not in sheet_data.columns:
                     sheet_data["Para_Birimi"] = sheet_data["Fiyat_Ham"].astype(str).apply(detect_currency)
                 sheet_data["Kaynak_Dosya"] = _basename(filepath, filename)
+                brand_from_file = detect_brand(_basename(filepath, filename))
                 year_match = None
                 if price_col:
                     year_match = re.search(r"(\d{4})", str(price_col))
                 sheet_data["Yil"] = int(year_match.group(1)) if year_match else None
-                sheet_data["Marka"] = sheet_data["Malzeme_Adi"].astype(str).apply(detect_brand)
+                if brand_from_file:
+                    sheet_data["Marka"] = brand_from_file
+                else:
+                    sheet_data["Marka"] = sheet_data["Malzeme_Adi"].astype(str).apply(detect_brand)
                 sheet_data["Kategori"] = None
                 sheet_data["Sayfa"] = sheet
                 all_data.append(sheet_data)

--- a/core/extract_pdf.py
+++ b/core/extract_pdf.py
@@ -106,7 +106,11 @@ def extract_from_pdf(
     df["Malzeme_Adi"] = df["Malzeme_Adi"].str.replace(r"^[A-Z0-9\-/]{3,}\s+", "", regex=True)
     df["Kaynak_Dosya"] = _basename(filepath, filename)
     df["Yil"] = None
-    df["Marka"] = df["Malzeme_Adi"].apply(detect_brand)
+    brand_from_file = detect_brand(_basename(filepath, filename))
+    if brand_from_file:
+        df["Marka"] = brand_from_file
+    else:
+        df["Marka"] = df["Malzeme_Adi"].apply(detect_brand)
     df["Kategori"] = None
     cols = [
         "Malzeme_Kodu",


### PR DESCRIPTION
## Summary
- detect brand names from file names
- prefer file name brand when extracting Excel or PDF data
- test brand extraction logic

## Testing
- `pytest -q`