### PR TITLE
Support multi-word brand detection

### DIFF
--- a/core/common_utils.py
+++ b/core/common_utils.py
@@ -103,7 +103,19 @@ def detect_brand(text: str) -> Optional[str]:
     match = re.search(r"\.([A-Za-z0-9]{2,4})$", base)
     if match:
         base = os.path.splitext(base)[0]
-        for token in re.split(r"[\s_-]+", base):
-            if re.search(r"[A-Za-z]", token):
-                return token
+        tokens = re.split(r"[\s_-]+", base)
+        brand_parts = []
+        for token in tokens:
+            if not token:
+                continue
+            if not brand_parts:
+                if re.search(r"[A-Za-z]", token):
+                    brand_parts.append(token)
+                continue
+            if re.match(r"[A-Z].*", token) or token.isupper():
+                brand_parts.append(token)
+            else:
+                break
+        if brand_parts:
+            return " ".join(brand_parts)
     return None

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -107,6 +107,11 @@ def test_detect_brand_from_filename():
     assert detect_brand("/path/to/BrandB-2021.pdf") == "BrandB"
 
 
+def test_detect_brand_from_filename_multi_word():
+    assert detect_brand("Omega Motor_list.xlsx") == "Omega Motor"
+    assert detect_brand("ACME_Corp-2023.pdf") == "ACME Corp"
+
+
 def test_extract_from_excel_brand_from_filename(tmp_path):
     if not HAS_PANDAS:
         pytest.skip("pandas not installed")
@@ -135,6 +140,20 @@ def test_extract_from_excel_brand_filename_param():
 
     result = extract_from_excel(buf, filename="BrandX_prices.xlsx")
     assert result.iloc[0]["Marka"] == "BrandX"
+
+
+def test_extract_from_excel_brand_from_filename_multiword(tmp_path):
+    if not HAS_PANDAS:
+        pytest.skip("pandas not installed")
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    df = pd.DataFrame({"Ürün Adı": ["Elma"], "Fiyat": ["1.000,50"]})
+    file = tmp_path / "Omega Motor_list.xlsx"
+    df.to_excel(file, index=False)
+
+    result = extract_from_excel(str(file))
+    assert result.iloc[0]["Marka"] == "Omega Motor"
 
 
 def test_extract_from_excel_short_code(tmp_path):


### PR DESCRIPTION
## Summary
- enhance `detect_brand` to capture consecutive capitalized tokens as one brand
- test multi-word brand detection from filenames
- test multi-word brand extraction in Excel helper

## Testing
- `pytest -q`