### PR TITLE
Fix header lists for product codes

### DIFF
--- a/core/extract_excel.py
+++ b/core/extract_excel.py
@@ -24,11 +24,14 @@ POSSIBLE_CODE_HEADERS = [
     'ürün numarası',
     'item no',
     'product no',
+    'malzeme adı',
+    'malzeme',
+    'ürün',
+    'product name',
+    'name',
 ]
 POSSIBLE_DESC_HEADERS = [
     'ürün adı',
-    'malzeme adı',
-    'product name',
     'item name',
     'description',
     'ürün açıklaması',
@@ -172,6 +175,8 @@ def extract_from_excel(
     combined["Fiyat"] = combined["Fiyat_Ham"].apply(normalize_price)
     if "Kisa_Kod" not in combined.columns:
         combined["Kisa_Kod"] = None
+    if "Malzeme_Kodu" not in combined.columns:
+        combined["Malzeme_Kodu"] = None
     combined.rename(columns={"Malzeme_Adi": "Descriptions"}, inplace=True)
     cols = [
         "Malzeme_Kodu",

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -57,6 +57,7 @@ def test_extract_from_excel_basic(tmp_path):
     ]
     assert result.columns.tolist() == expected_cols
     assert result["Kisa_Kod"].isnull().all()
+    assert result["Malzeme_Kodu"].isnull().all()
 
 
 def test_extract_from_excel_xls(tmp_path):


### PR DESCRIPTION
## Summary
- move several headers from description to code list
- ensure "Malzeme Adı", "Malzeme", "Ürün", "Product Name", "Name" are treated as code headers

## Testing
- `pytest -q`
