### PR TITLE
Fix Excel description handling

### DIFF
--- a/core/extract_excel.py
+++ b/core/extract_excel.py
@@ -161,8 +161,12 @@ def extract_from_excel(
                     mapping[short_col] = "Kisa_Kod"
                 if desc_col and desc_col in df.columns:
                     mapping[desc_col] = "Malzeme_Adi"
-                elif code_col and code_col in df.columns and "Malzeme_Adi" not in mapping.values():
-                    mapping[code_col] = "Malzeme_Adi"
+                else:
+                    # If no dedicated description column exists, duplicate the
+                    # code column rather than renaming it so both fields are
+                    # populated.
+                    if code_col and code_col in df.columns:
+                        sheet_data["Malzeme_Adi"] = df[code_col]
                 mapping[price_col] = "Fiyat_Ham"
                 if currency_col and currency_col in df.columns:
                     mapping[currency_col] = "Para_Birimi"

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -78,6 +78,21 @@ def test_extract_from_excel_xls(tmp_path):
     assert result["Descriptions"].tolist() == ["Elma"]
 
 
+def test_extract_from_excel_code_only(tmp_path):
+    if not HAS_PANDAS:
+        pytest.skip("pandas not installed")
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    df = pd.DataFrame({"Ürün Kodu": ["C1", "D2"], "Fiyat": ["10", "20"]})
+    file = tmp_path / "code_only.xlsx"
+    df.to_excel(file, index=False)
+
+    result = extract_from_excel(str(file))
+    assert result["Malzeme_Kodu"].tolist() == ["C1", "D2"]
+    assert result["Descriptions"].tolist() == ["C1", "D2"]
+
+
 def test_extract_from_excel_bytesio():
     if not HAS_PANDAS:
         pytest.skip("pandas not installed")


### PR DESCRIPTION
## Summary
- handle missing description columns by duplicating the code column
- test that code is copied into descriptions when no description header exists

## Testing
- `pytest -q`