### PR TITLE
Add OCR support for PDF parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "streamlit",
     "openpyxl",
     "xlrd",
+    "pdf2image",
+    "pytesseract",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add `pdf2image` and `pytesseract` as dependencies
- extend PDF extraction with OCR fallback using `pdf2image` and `pytesseract`
- include optional LLM hook
- mock OCR modules in tests and cover OCR fallback

## Testing
- `pytest -q`