### PR TITLE
Fix file-like support in PDF extraction

### DIFF
--- a/core/extract_pdf.py
+++ b/core/extract_pdf.py
@@ -55,7 +55,7 @@ def extract_from_pdf(
                 filepath.seek(0)
             except Exception:
                 pass
-            cm = pdfplumber.open(file=filepath)
+            cm = pdfplumber.open(filepath)
         with cm as pdf:
             for page in pdf.pages:
                 page_added = False

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -538,8 +538,8 @@ def test_extract_from_pdf_bytesio(monkeypatch):
 
     assert len(result) == 1
     assert result.iloc[0]["Fiyat"] == 55.0
-    assert calls.get("kwargs", {}).get("file") is buf
-    assert calls.get("args") == ()
+    assert calls.get("args") == (buf,)
+    assert calls.get("kwargs") == {}
 
 
 def test_merge_files_casts_to_string(monkeypatch):


### PR DESCRIPTION
## Summary
- handle file-like objects in `extract_from_pdf` by calling `pdfplumber.open` with the buffer as a positional argument
- update `test_extract_from_pdf_bytesio` to check positional argument

## Testing
- `pytest -q`