### PR TITLE
Add 'TİP' column header support

### DIFF
--- a/core/extract_excel.py
+++ b/core/extract_excel.py
@@ -41,6 +41,7 @@ _RAW_CODE_HEADERS = [
     'ürün',
     'product name',
     'name',
+    'tip',
 ]
 _RAW_DESC_HEADERS = [
     'item name',

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -203,6 +203,21 @@ def test_extract_from_excel_code_only(tmp_path):
     assert result["Descriptions"].tolist() == ["C1", "D2"]
 
 
+def test_extract_from_excel_tip_header(tmp_path):
+    if not HAS_PANDAS:
+        pytest.skip("pandas not installed")
+    pytest.importorskip("openpyxl")
+    import pandas as pd
+
+    df = pd.DataFrame({"TİP": ["C1", "D2"], "Fiyat": ["10", "20"]})
+    file = tmp_path / "tip.xlsx"
+    df.to_excel(file, index=False)
+
+    result = extract_from_excel(str(file))
+    assert result["Malzeme_Kodu"].tolist() == ["C1", "D2"]
+    assert result["Descriptions"].tolist() == ["C1", "D2"]
+
+
 def test_extract_from_excel_bytesio():
     if not HAS_PANDAS:
         pytest.skip("pandas not installed")


### PR DESCRIPTION
## Summary
- recognize **TİP** as a material code column
- cover header with a new regression test

## Testing
- `pytest -q`