### PR TITLE
Handle save errors when saving master dataset

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -128,8 +128,13 @@ def upload_page():
         st.success(f"{len(df)} kayıt bulundu")
         st.dataframe(df)
         if st.button("Master Veriyi Kaydet"):
-            df.to_excel("master_dataset.xlsx", index=False)
-            st.success("master_dataset.xlsx kaydedildi")
+            data_path = get_master_dataset_path()
+            try:
+                df.to_excel(data_path, index=False)
+            except Exception as exc:  # pragma: no cover - UI feedback only
+                st.error(f"Kaydetme hatası: {exc}")
+            else:
+                st.success(f"{os.path.basename(data_path)} kaydedildi")
 
 
 def search_page():


### PR DESCRIPTION
## Summary
- wrap the Excel file save in a try/except block
- surface any exception with a Streamlit error message
- reuse `get_master_dataset_path()` for the dataset path

## Testing
- `pytest -q`