### PR TITLE
Update master save path display

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,5 @@ smart-price-app
 ```
 
 From the interface you can upload Excel/PDF price lists and search the
-resulting master dataset.
+resulting master dataset. The merged data is written to `master_dataset.xlsx`
+in the directory from which you launch the app.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -128,13 +128,13 @@ def upload_page():
         st.success(f"{len(df)} kayıt bulundu")
         st.dataframe(df)
         if st.button("Master Veriyi Kaydet"):
-            data_path = get_master_dataset_path()
+            data_path = os.path.abspath(get_master_dataset_path())
             try:
                 df.to_excel(data_path, index=False)
             except Exception as exc:  # pragma: no cover - UI feedback only
                 st.error(f"Kaydetme hatası: {exc}")
             else:
-                st.success(f"{os.path.basename(data_path)} kaydedildi")
+                st.success(f"{data_path} konumuna kaydedildi")
 
 
 def search_page():


### PR DESCRIPTION
## Summary
- clarify where the merged dataset is saved in the README
- show the absolute location when saving from the Streamlit interface

## Testing
- `pytest -q`