### PR TITLE
Handle empty LLM items with log

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,15 @@ project directory (or whichever path is passed to `init_logging`). This log
 captures detailed processing messages and is created automatically each time the
 tools run. Open this file with a text editor or use commands such as
 `tail -f smart_price.log` to inspect the output when troubleshooting.
+
+## Troubleshooting
+
+When the OCR phase hands text to the language model but no items are parsed, the
+log records the model name and a short excerpt of the OCR text. Look for entries
+like:
+
+```
+no items parsed by gpt-3.5-turbo; OCR text excerpt: 'Example line from scan'
+```
+
+This can help diagnose why the extraction failed.

--- a/core/extract_pdf.py
+++ b/core/extract_pdf.py
@@ -101,6 +101,12 @@ def extract_from_pdf(
             try:
                 cleaned = gpt_clean_text(content)
                 items = json.loads(cleaned)
+                if not items:
+                    excerpt = text[:100].replace("\n", " ")
+                    notify(
+                        f"no items parsed by {model_name}; OCR text excerpt: {excerpt!r}"
+                    )
+                    return []
             except json.JSONDecodeError:
                 notify(f"LLM returned invalid JSON: {content!r}")
                 notify("LLM returned no data")

--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -141,6 +141,17 @@ def test_llm_custom_model(monkeypatch):
     assert captured == ['foo-model']
 
 
+def test_llm_empty_items_logs_excerpt(monkeypatch):
+    logs = []
+    func = _get_llm_func(logs.append)
+    _setup_openai(monkeypatch, '[]')
+    text = 'foo\nbar ' * 20
+    result = func(text)
+    assert result == []
+    assert any('no items parsed by' in msg for msg in logs)
+    assert 'gpt-3.5-turbo' in ''.join(logs)
+
+
 def test_llm_prompt_and_clean(monkeypatch):
     logs = []
     func = _get_llm_func(logs.append)


### PR DESCRIPTION
## Summary
- log a short excerpt and model name when the LLM returns no items
- mention the log entry in README troubleshooting docs
- test that the new log message appears

## Testing
- `pytest -q`