### PR TITLE
Update logging and README for new extraction flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ pip install .
 
 `tkinter` must also be available. It is typically included with many Python distributions but may require a separate installation on some systems.
 
-PDF lists that cannot be read directly fall back to OCR. This requires the
-`pdftoppm` utility from **Poppler** and **Tesseract** itself. On Debian based
+PDF files are processed in two stages. First the parser attempts to read text directly using **pdfplumber**. If no products are found the entire document is converted to images with `pdftoppm` and recognised by **Tesseract**. The resulting text is then interpreted by a language model.
+Both `pdftoppm` from **Poppler** and **Tesseract** itself must therefore be installed. On Debian based
 Linux systems install them with:
 
 ```bash
@@ -24,13 +24,13 @@ Windows users can download the Poppler and Tesseract binaries and ensure that
 `pdftoppm.exe` and `tesseract.exe` are available in the `PATH`. Both utilities
 must be discoverable on your system PATH for the OCR phase to succeed.
 
-### Optional LLM assistance
+### LLM assistance
 
-If OCR results are hard to parse the tool can employ GPT-3.5 to interpret the
-text. Set an `OPENAI_API_KEY` environment variable or provide a `.env` file with
-the key. Optionally set `OPENAI_MODEL` to override the default `gpt-3.5-turbo`
-model. The model is queried with a temperature of `0.2` and a small delay is
-added between requests to respect API rate limits.
+After OCR the recognised text is sent to GPT-3.5 for interpretation. Provide an
+`OPENAI_API_KEY` environment variable or a `.env` file containing the key to
+enable this step. Optionally set `OPENAI_MODEL` to override the default
+`gpt-3.5-turbo` model. The model is queried with a temperature of `0.2` and a
+small delay is added between requests to respect API rate limits.
 
 ### Building a Windows executable
 
@@ -90,8 +90,9 @@ tools run. Open this file with a text editor or use commands such as
 
 ## Troubleshooting
 
-When the OCR phase hands text to the language model but no items are parsed, the
-log records the model name and a short excerpt of the OCR text. Look for entries
+If the second stage (OCR followed by the language model) fails to produce any
+items, the log records the model name and a short excerpt of the recognised text.
+Look for entries
 like:
 
 ```

--- a/core/extract_pdf.py
+++ b/core/extract_pdf.py
@@ -61,7 +61,7 @@ def extract_from_pdf(
     def _llm_extract_from_image(text: str) -> list[dict]:
         """Use a language model to extract product names and prices from OCR text."""
         # pragma: no cover - not exercised in tests
-        notify("LLM extraction started")
+        notify("LLM fazı başladı")
         try:
             from dotenv import load_dotenv  # type: ignore
             load_dotenv()
@@ -259,9 +259,9 @@ def extract_from_pdf(
             except Exception as exc:
                 notify(f"OCR libraries unavailable: {exc}")
             else:
+                notify("OCR faz\u0131 başladı")
                 images = convert_from_path(path_for_ocr)
                 ocr_text = "\n".join(pytesseract.image_to_string(img) for img in images)
-                notify("LLM faz\u0131")
                 llm_data = _llm_extract_from_image(ocr_text)
                 if llm_data:
                     notify(f"LLM parsed {len(llm_data)} items")

--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -100,7 +100,7 @@ def test_llm_extract_valid_json(monkeypatch):
         'Fiyat': 10.0,
         'Para_Birimi': 'TRY'
     }]
-    assert logs[0].startswith("LLM extraction started")
+    assert logs[0].startswith("LLM fazı başladı")
     assert logs[-1] == "LLM parsed 1 items"
 
 
@@ -115,7 +115,7 @@ def test_llm_extract_extra_text(monkeypatch):
         'Fiyat': 5.0,
         'Para_Birimi': 'USD'
     }]
-    assert logs[0].startswith("LLM extraction started")
+    assert logs[0].startswith("LLM fazı başladı")
     assert logs[-1] == "LLM parsed 1 items"
 
 
@@ -126,7 +126,7 @@ def test_llm_extract_invalid_json(monkeypatch):
     result = func('ignored')
     assert result == []
     assert any('invalid JSON' in msg for msg in logs)
-    assert logs[0].startswith("LLM extraction started")
+    assert logs[0].startswith("LLM fazı başladı")
     assert logs[-1] == "LLM returned no data"
 
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -694,4 +694,5 @@ def test_extract_from_pdf_llm_sets_page_added(monkeypatch):
 
     assert not df.empty
     assert len(llm_calls) == 1
-    assert any("LLM faz\u0131" in m for m in logs)
+    assert any("OCR faz\u0131 başladı" in m for m in logs)
+    assert any("LLM faz\u0131 başladı" in m for m in logs)


### PR DESCRIPTION
## Summary
- document new two-stage PDF extraction in README
- refine OCR/LLM log messages
- adjust tests for updated messages

## Testing
- `pytest -q`