### PR TITLE
Add start time logging for extraction functions

### DIFF
--- a/core/extract_excel.py
+++ b/core/extract_excel.py
@@ -7,6 +7,7 @@ from typing import Tuple, Optional, IO, Any
 
 import pandas as pd
 import logging
+from datetime import datetime
 from .common_utils import (
     normalize_price,
     select_latest_year_column,
@@ -134,6 +135,8 @@ def extract_from_excel(
     filepath: str | IO[bytes], *, filename: str | None = None
 ) -> pd.DataFrame:
     """Extract product information from an Excel file."""
+    src = _basename(filepath, filename)
+    logger.info(f"Processing {src} started at {datetime.now():%Y-%m-%d %H:%M:%S}")
     all_data = []
     try:
         ext = os.path.splitext(filename or _basename(filepath))[1].lower()

--- a/core/extract_pdf.py
+++ b/core/extract_pdf.py
@@ -5,6 +5,7 @@ import io
 import tempfile
 from typing import IO, Any, Optional
 import logging
+from datetime import datetime
 
 import pandas as pd
 import pdfplumber
@@ -57,6 +58,9 @@ def extract_from_pdf(
                 log(message)
             except Exception as exc:  # pragma: no cover - log callback errors
                 logger.error("log callback failed: %s", exc)
+
+    src = _basename(filepath, filename)
+    notify(f"Processing {src} started at {datetime.now():%Y-%m-%d %H:%M:%S}")
 
     def _llm_extract_from_image(text: str) -> list[dict]:
         """Use a language model to extract product names and prices from OCR text."""


### PR DESCRIPTION
## Summary
- log processing start time in `extract_from_pdf`
- add equivalent logging for `extract_from_excel`

## Testing
- `pytest -q`