### PR TITLE
Add phase 1 logging

### DIFF
--- a/core/extract_pdf.py
+++ b/core/extract_pdf.py
@@ -269,6 +269,9 @@ def extract_from_pdf(
                         notify(f"table parse error: {exc}")
                         continue
 
+        phase1_count = len(data)
+        if phase1_count:
+            notify(f"Phase 1 parsed {phase1_count} items; skipping OCR/LLM")
         if not data:
             try:
                 from pdf2image import convert_from_path  # type: ignore
@@ -326,4 +329,6 @@ def extract_from_pdf(
         "Marka",
         "Kaynak_Dosya",
     ]
-    return df[cols].dropna(subset=["Descriptions", "Fiyat"])
+    result_df = df[cols].dropna(subset=["Descriptions", "Fiyat"])
+    notify(f"Finished {src} with {len(result_df)} items")
+    return result_df

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -586,11 +586,13 @@ def test_extract_from_pdf_bytesio(monkeypatch):
     monkeypatch.setattr(pdfplumber_mod, "open", fake_open, raising=False)
 
     buf = io.BytesIO(b"pdf")
-    result = extract_from_pdf(buf, filename="dummy.pdf")
+    logs = []
+    result = extract_from_pdf(buf, filename="dummy.pdf", log=logs.append)
 
     assert len(result) == 1
     assert result.iloc[0]["Fiyat"] == 55.0
     assert calls.get("args") == (buf,)
+    assert any("Phase 1 parsed" in m for m in logs)
     assert calls.get("kwargs") == {}
 
 


### PR DESCRIPTION
## Summary
- log how many records were parsed in the first phase of PDF extraction
- show total parsed items when extraction completes
- test that phase 1 logs appear when data is found

## Testing
- `pytest -q`