### PR TITLE
Implement parse quality checks with OCR fallback

### DIFF
--- a/core/ocr_llm_fallback.py
+++ b/core/ocr_llm_fallback.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def parse(path: str, page_range=None) -> pd.DataFrame:
+    """Fallback OCR + LLM parser placeholder."""
+    return pd.DataFrame()


### PR DESCRIPTION
## Summary
- add fallback parser stub `ocr_llm_fallback.parse`
- compute quality metrics on PDF extraction
- call OCR+LLM fallback when parsed data looks unreliable
- ensure temporary OCR files are always cleaned up

## Testing
- `pytest -q`