### PR TITLE
Update headers for extract_excel

### DIFF
--- a/smart_price/core/extract_excel.py
+++ b/smart_price/core/extract_excel.py
@@ -40,9 +40,12 @@ _RAW_CODE_HEADERS = [
     "ürün tip",
     "product code",
     "part no",
+    "item name",
+    "item no",
+    "item number",
+    "item #",
 ]
 _RAW_DESC_HEADERS = [
-    "item name",
     "description",
     "ürün açıklaması",
     "açıklama",

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+import importlib
+
+# Ensure repo root is on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _import_module(monkeypatch):
+    """Import extract_excel with minimal stubs if pandas is missing."""
+    try:
+        import pandas  # noqa: F401
+    except ModuleNotFoundError:
+        stub = types.ModuleType("pandas")
+        stub.DataFrame = type("DataFrame", (), {})
+        monkeypatch.setitem(sys.modules, "pandas", stub)
+    for name in ("pdfplumber", "tkinter", "pdf2image", "pytesseract", "streamlit"):
+        if name not in sys.modules:
+            monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    module = importlib.import_module("smart_price.core.extract_excel")
+    importlib.reload(module)
+    return module
+
+
+def test_item_headers_only_in_code(monkeypatch):
+    ee = _import_module(monkeypatch)
+    headers = {"item name", "item no", "item number", "item #"}
+    assert headers.issubset(ee.POSSIBLE_CODE_HEADERS)
+    normalized = {ee._norm_header(h) for h in headers}
+    code_normalized = {ee._norm_header(h) for h in ee.POSSIBLE_CODE_HEADERS}
+    for h in normalized:
+        assert h in code_normalized
+        assert h not in ee.POSSIBLE_DESC_HEADERS


### PR DESCRIPTION
## Summary
- expand possible product code headers
- remove `item name` from description headers
- verify code/description header lists in new unit test

## Testing
- `pytest -q`