### PR TITLE
Add run_app.py launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Launch the web UI locally with:
 ```bash
 smart-price-app
 ```
+Alternatively run the included launcher script from the repository root:
+```bash
+python run_app.py
+```
 
 From the interface you can upload Excel/PDF price lists and search the
 resulting master dataset. The merged data is written to `master_dataset.xlsx`

--- a/run_app.py
+++ b/run_app.py
@@ -1,0 +1,12 @@
+import sys
+import pathlib
+from streamlit.web import cli as stcli
+
+if __name__ == "__main__":
+    pkg_root = pathlib.Path(__file__).parent
+    sys.argv = [
+        "streamlit",
+        "run",
+        str(pkg_root / "smart_price" / "streamlit_app.py"),
+    ]
+    stcli.main()


### PR DESCRIPTION
## Summary
- add a simple launcher script for running the Streamlit app
- document `run_app.py` usage in README

## Testing
- `pytest -q`