### PR TITLE
Fix Tesseract data path for Turkish OCR

### DIFF
--- a/smart_price/streamlit_app.py
+++ b/smart_price/streamlit_app.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("smart_price")
 
 def _configure_tesseract() -> None:
     """Configure pytesseract paths and log available languages."""
-    os.environ["TESSDATA_PREFIX"] = r"D:\\Program Files\\Tesseract-OCR"
+    os.environ["TESSDATA_PREFIX"] = r"D:\\Program Files\\Tesseract-OCR\\tessdata"
     pytesseract.pytesseract.tesseract_cmd = (
         r"D:\\Program Files\\Tesseract-OCR\\tesseract.exe"
     )


### PR DESCRIPTION
## Summary
- fix TESSDATA_PREFIX path in streamlit app to correctly point at `tessdata`

## Testing
- `pytest -q`