### PR TITLE
Update OpenAI usage

### DIFF
--- a/smart_price/core/extract_pdf.py
+++ b/smart_price/core/extract_pdf.py
@@ -109,13 +109,13 @@ def extract_from_pdf(
             return []
 
         try:
-            import openai  # type: ignore
+            from openai import OpenAI
         except Exception as exc:  # pragma: no cover - optional dep missing
             notify(f"openai import failed: {exc}")
             notify("LLM returned no data")
             return []
 
-        client = openai.OpenAI(api_key=api_key)  # type: ignore[attr-defined]
+        client = OpenAI(api_key=api_key)
 
         model_name = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
         excerpt = text[:200].replace("\n", " ")

--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -74,15 +74,14 @@ def parse(pdf_path: str, page_range: Iterable[int] | range | None = None) -> pd.
         os.environ.setdefault("OPENAI_API_KEY", api_key)
 
     try:
-        import openai  # type: ignore
-        resp = openai.ChatCompletion.create(
-            model="gpt-4o-mini",
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0,
-        )
-        content = resp["choices"][0]["message"]["content"]
-    except AttributeError:  # pragma: no cover - openai>=1.0
-        client = openai.OpenAI(api_key=api_key)  # type: ignore[attr-defined]
+        from openai import OpenAI
+    except Exception as exc:  # pragma: no cover - import errors
+        logger.error("OpenAI import failed: %s", exc)
+        return pd.DataFrame()
+
+    client = OpenAI(api_key=api_key)
+
+    try:
         resp = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=[{"role": "user", "content": prompt}],


### PR DESCRIPTION
## Summary
- use OpenAI client from openai>=1.0 in OCR extraction
- drop fallback for legacy ChatCompletion API

## Testing
- `pytest -q`