### PR TITLE
Load env vars before starting Streamlit

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -1,6 +1,11 @@
+import os
 import sys
 import pathlib
+from dotenv import load_dotenv
 from streamlit.web import cli as stcli
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".env"))
+load_dotenv(dotenv_path=project_root)
 
 if __name__ == "__main__":
     pkg_root = pathlib.Path(__file__).parent


### PR DESCRIPTION
## Summary
- load environment variables from `.env` in `run_app.py` so Streamlit gets configuration

## Testing
- `pytest -q`