### PR TITLE
Load dotenv before configuring logger

### DIFF
--- a/smart_price/core/logger.py
+++ b/smart_price/core/logger.py
@@ -1,6 +1,10 @@
 import logging
 import os
 from pathlib import Path
+from dotenv import load_dotenv
+
+project_root = Path(__file__).resolve().parent.parent / ".env"
+load_dotenv(dotenv_path=project_root)
 
 
 def init_logging(log_path: str = "smart_price.log", *, level: int | str | None = None) -> logging.Logger:


### PR DESCRIPTION
## Summary
- ensure SMART_PRICE_DEBUG is read by loading .env from repo root

## Testing
- `pytest -q`