### PR TITLE
Initialize dotenv in PDF and OCR modules

### DIFF
--- a/smart_price/core/extract_pdf.py
+++ b/smart_price/core/extract_pdf.py
@@ -13,6 +13,12 @@ import pandas as pd
 import pdfplumber
 import json
 import time
+from dotenv import load_dotenv
+
+try:
+    load_dotenv("../..")
+except TypeError:  # pragma: no cover - allow stub without args
+    load_dotenv()
 
 # Optional OCR dependencies are imported lazily within extract_from_pdf
 import re
@@ -97,12 +103,8 @@ def extract_from_pdf(
         """Use a language model to extract product names and prices from OCR text."""
         # pragma: no cover - not exercised in tests
         notify("LLM fazı başladı")
-        try:
-            from dotenv import load_dotenv  # type: ignore
-            load_dotenv()
-        except Exception as exc:  # pragma: no cover - optional dep missing
-            notify(f"dotenv load failed: {exc}")
-
+        # Environment already loaded at module import time
+        pass
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key or not text:
             notify("LLM returned no data")

--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -4,6 +4,12 @@ import json
 import logging
 import os
 from typing import Iterable, Sequence
+from dotenv import load_dotenv
+
+try:
+    load_dotenv("../..")
+except TypeError:  # pragma: no cover - allow stub without args
+    load_dotenv()
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- load environment from project root in `extract_pdf` and `ocr_llm_fallback`
- avoid reloading dotenv inside `_llm_extract_from_image`

## Testing
- `pytest -q`