### PR TITLE
Add per-page debug outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Set the environment variable `SMART_PRICE_DEBUG=1` (or pass
 `level=logging.DEBUG` when calling `init_logging`) to enable verbose debug
 information. When active the log includes the chosen LLM model, a short excerpt
 of the OCR text, the constructed prompt length and the raw response returned by
-the OpenAI API.
+the OpenAI API. OCR text for each page and every LLM prompt/response are also
+written to a folder.
 
 #### Debug information
 
@@ -109,6 +110,8 @@ step:
 - an excerpt of the recognised text
 - a snippet of the prompt sent to the LLM
 - and the first items parsed from the response.
+- per-page debug files stored under `output_debug` (set
+  `SMART_PRICE_DEBUG_DIR` to change the folder)
 
 ## Troubleshooting
 

--- a/smart_price/core/debug_utils.py
+++ b/smart_price/core/debug_utils.py
@@ -1,0 +1,31 @@
+import os
+import logging
+from pathlib import Path
+
+logger = logging.getLogger("smart_price")
+
+
+def _debug_enabled() -> bool:
+    return bool(os.getenv("SMART_PRICE_DEBUG"))
+
+
+def _debug_dir() -> Path:
+    path = Path(os.getenv("SMART_PRICE_DEBUG_DIR", "output_debug"))
+    if _debug_enabled():
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except Exception as exc:  # pragma: no cover - optional debug failures
+            logger.debug("debug dir creation failed: %s", exc)
+    return path
+
+
+def save_debug(prefix: str, page: int, content: str) -> None:
+    if not _debug_enabled():
+        return
+    dir_path = _debug_dir()
+    file_path = dir_path / f"{prefix}_page_{page:02d}.txt"
+    try:
+        with open(file_path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    except Exception as exc:  # pragma: no cover - debug file failures
+        logger.debug("debug write failed for %s: %s", file_path, exc)

--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -14,6 +14,7 @@ except TypeError:  # pragma: no cover - allow stub without args
 import pandas as pd
 
 from .common_utils import gpt_clean_text
+from .debug_utils import save_debug
 
 logger = logging.getLogger("smart_price")
 
@@ -62,6 +63,7 @@ def parse(pdf_path: str, page_range: Iterable[int] | range | None = None) -> pd.
             logger.debug("OCR page %d length %d", idx, len(text))
             if text:
                 ocr_text_parts.append(text)
+                save_debug("ocr_text", idx, text)
         except Exception as exc:  # pragma: no cover - OCR errors
             logger.error("OCR failed on page %d: %s", idx, exc)
 
@@ -74,6 +76,7 @@ def parse(pdf_path: str, page_range: Iterable[int] | range | None = None) -> pd.
         "Extract JSON [{code, price, descr}] from the text below. "
         "Return only valid JSON.\n\n" + ocr_text
     )
+    save_debug("llm_prompt", 1, prompt)
 
     api_key = os.getenv("OPENAI_API_KEY")
     if api_key:
@@ -94,6 +97,7 @@ def parse(pdf_path: str, page_range: Iterable[int] | range | None = None) -> pd.
             temperature=0,
         )
         content = resp.choices[0].message.content
+        save_debug("llm_response", 1, content)
     except Exception as exc:  # pragma: no cover - request errors
         logger.error("OpenAI request failed: %s", exc)
         return pd.DataFrame()


### PR DESCRIPTION
## Summary
- capture OCR text, LLM prompts and responses when SMART_PRICE_DEBUG=1
- store debug files in a configurable directory via `SMART_PRICE_DEBUG_DIR`
- document debug folder in README

## Testing
- `pytest -q`