### PR TITLE
Add vision-based LLM fallback

### DIFF
--- a/smart_price/core/debug_utils.py
+++ b/smart_price/core/debug_utils.py
@@ -1,6 +1,9 @@
 import os
 import logging
 from pathlib import Path
+from typing import Optional
+
+from PIL import Image  # type: ignore
 
 logger = logging.getLogger("smart_price")
 
@@ -29,3 +32,32 @@ def save_debug(prefix: str, page: int, content: str) -> None:
             fh.write(content)
     except Exception as exc:  # pragma: no cover - debug file failures
         logger.debug("debug write failed for %s: %s", file_path, exc)
+
+
+def save_debug_image(prefix: str, page: int, image: Image.Image) -> Optional[Path]:
+    """Save ``image`` under the debug directory if debugging is enabled.
+
+    Parameters
+    ----------
+    prefix : str
+        Name prefix for the saved file.
+    page : int
+        Page number used in the file name.
+    image : :class:`PIL.Image.Image`
+        Image to save.
+
+    Returns
+    -------
+    pathlib.Path or None
+        Path of the saved image if debugging is on, otherwise ``None``.
+    """
+    if not _debug_enabled():
+        return None
+
+    dir_path = _debug_dir()
+    file_path = dir_path / f"{prefix}_page_{page:02d}.png"
+    try:
+        image.save(file_path, format="PNG")
+    except Exception as exc:  # pragma: no cover - debug file failures
+        logger.debug("debug image write failed for %s: %s", file_path, exc)
+    return file_path

--- a/smart_price/streamlit_app.py
+++ b/smart_price/streamlit_app.py
@@ -73,10 +73,10 @@ def extract_from_pdf_file(
     *,
     file_name: str | None = None,
     status_log: Optional[Callable[[str], None]] = None,
-    force_ocr: bool = False,
+    force_llm: bool = False,
 ) -> pd.DataFrame:
     """Wrapper around :func:`smart_price.core.extract_pdf.extract_from_pdf`."""
-    return extract_from_pdf(file, filename=file_name, log=status_log, force_ocr=force_ocr)
+    return extract_from_pdf(file, filename=file_name, log=status_log, force_llm=force_llm)
 
 
 def merge_files(
@@ -84,7 +84,7 @@ def merge_files(
     *,
     update_status: Optional[Callable[[str], None]] = None,
     update_progress: Optional[Callable[[float], None]] = None,
-    force_ocr: bool = False,
+    force_llm: bool = False,
 ):
     """Extract and merge uploaded files with optional progress callbacks."""
     extracted = []
@@ -106,7 +106,7 @@ def merge_files(
                     bytes_data,
                     file_name=up_file.name,
                     status_log=update_status,
-                    force_ocr=force_ocr,
+                    force_llm=force_llm,
                 )
         except Exception:
             df = pd.DataFrame()
@@ -153,7 +153,7 @@ def upload_page():
         type=["xlsx", "xls", "pdf"],
         accept_multiple_files=True,
     )
-    force_ocr = st.checkbox("Force OCR/LLM")
+    force_llm = st.checkbox("Force LLM (Vision)")
     if not files:
         return
 
@@ -164,7 +164,7 @@ def upload_page():
             files,
             update_status=status.write,
             update_progress=lambda v: progress_bar.progress(v),
-            force_ocr=force_ocr,
+            force_llm=force_llm,
         )
         if df.empty:
             st.warning("Dosyalardan veri çıkarılamadı.")

--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -24,6 +24,15 @@ if 'pdf2image' not in sys.modules:
     sys.modules['pdf2image'] = types.ModuleType('pdf2image')
 if 'pytesseract' not in sys.modules:
     sys.modules['pytesseract'] = types.ModuleType('pytesseract')
+if 'PIL' not in sys.modules:
+    pil_stub = types.ModuleType('PIL')
+    image_stub = types.ModuleType('PIL.Image')
+    class FakeImg:  # pragma: no cover - simple stub
+        pass
+    image_stub.Image = FakeImg
+    pil_stub.Image = image_stub
+    sys.modules['PIL'] = pil_stub
+    sys.modules['PIL.Image'] = image_stub
 if 'streamlit' not in sys.modules:
     sys.modules['streamlit'] = types.ModuleType('streamlit')
 if 'dotenv' not in sys.modules:


### PR DESCRIPTION
## Summary
- add `save_debug_image` helper
- rewrite `ocr_llm_fallback.parse` for GPT-4o Vision
- switch PDF extraction to new vision fallback and rename flag to `force_llm`
- update Streamlit UI and tests for new parameter
- document vision fallback and remove Tesseract mention

## Testing
- `pytest -q`