### PR TITLE
Migrate to OpenAI SDK 1.0 API

### DIFF
--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -94,7 +94,7 @@ def parse(pdf_path: str, page_range: Iterable[int] | range | None = None) -> pd.
             with open(tmp_path, "rb") as f:
                 image_bytes = f.read()
             img_base64 = base64.b64encode(image_bytes).decode()
-            resp = openai.ChatCompletion.create(
+            resp = openai.chat.completions.create(
                 model=model_name,
                 messages=[
                     {

--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -28,8 +28,8 @@ def _setup_openai(monkeypatch):
         return types.SimpleNamespace(
             choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='[]'))]
         )
-    chat_stub = types.SimpleNamespace(create=create)
-    openai_stub = types.SimpleNamespace(ChatCompletion=chat_stub)
+    chat_stub = types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    openai_stub = types.SimpleNamespace(chat=chat_stub)
     monkeypatch.setitem(sys.modules, 'openai', openai_stub)
     monkeypatch.setenv('OPENAI_API_KEY', 'x')
 


### PR DESCRIPTION
## Summary
- replace deprecated `openai.ChatCompletion.create` with `openai.chat.completions.create`
- adapt unit test stubs to new client path

## Testing
- `pytest -q`