### PR TITLE
Fix image_url object format

### DIFF
--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -103,7 +103,7 @@ def parse(pdf_path: str, page_range: Iterable[int] | range | None = None) -> pd.
                             {"type": "text", "text": prompt},
                             {
                                 "type": "image_url",
-                                "image_url": "data:image/png;base64," + img_base64,
+                                "image_url": {"url": "data:image/png;base64," + img_base64},
                             },
                         ],
                     }

--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -80,6 +80,6 @@ def test_parse_sends_bytes_and_cleans_tmp(monkeypatch):
 
     assert 'images' not in openai_calls
     first_msg = openai_calls['messages'][0]
-    assert first_msg['content'][1]['image_url'].startswith('data:image/png;base64,')
+    assert first_msg['content'][1]['image_url']['url'].startswith('data:image/png;base64,')
     for path in temp_paths:
         assert not os.path.exists(path)


### PR DESCRIPTION
## Summary
- align vision API parameters with latest spec by passing an object for `image_url`
- update tests to match new parameter format

## Testing
- `pytest -q`
