### PR TITLE
Improve JSON parsing for LLM output

### DIFF
--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -189,3 +189,16 @@ def test_llm_prompt_and_clean(monkeypatch):
         'Para_Birimi': None
     }]
 
+
+def test_llm_extract_mismatched_quotes(monkeypatch):
+    logs = []
+    func = _get_llm_func(logs.append)
+    content = "[{name:'Foo', price:'5 USD'}]"
+    _setup_openai(monkeypatch, content)
+    result = func('ignored')
+    assert result == [{
+        'Malzeme_Adi': 'Foo',
+        'Fiyat': 5.0,
+        'Para_Birimi': 'USD'
+    }]
+


### PR DESCRIPTION
## Summary
- add `safe_json_parse` helper to handle malformed JSON
- use it in `_llm_extract_from_image` and OCR fallback parser
- mark page as error if JSON can't be parsed
- cover new parsing cases with tests

## Testing
- `pytest -q`