### PR TITLE
Automatic debug output & record codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,29 +82,27 @@ captures detailed processing messages and is created automatically each time the
 tools run. Open this file with a text editor or use commands such as
 `tail -f smart_price.log` to inspect the output when troubleshooting.
 
-Set the environment variable `SMART_PRICE_DEBUG=1` (or pass
-`level=logging.DEBUG` when calling `init_logging`) to enable verbose debug
-information. When active the log includes the chosen LLM model, the constructed
-prompt length and the raw response returned by the OpenAI API. Per-page images
-and JSON responses are saved to a folder.
+Verbose details such as the chosen LLM model, prompt length and the raw
+response returned by the OpenAI API are logged automatically. Per page images
+and JSON responses are written to the `LLM_Output_db` directory under a
+subfolder matching the processed PDF name.
 
 #### Debug information
 
-When debug mode is enabled the log also records extra details to help trace each
-step:
+The log records extra details to help trace each step:
 
 - the name of the processed file
 - a timestamp for every event
 - page numbers for processed pages
 - a snippet of the prompt sent to the LLM
 - and the first items parsed from the response.
-- per-page debug files stored under `output_debug` (set
-  `SMART_PRICE_DEBUG_DIR` to change the folder)
+- per-page debug files stored under `LLM_Output_db/<PDF adı>` (set
+  `SMART_PRICE_DEBUG_DIR` to override the location)
 
 ## Troubleshooting
 
 If the vision stage fails to produce any items, the log records the model name
 and an excerpt of the prompt. This can help diagnose why the extraction failed.
 
-When debug logging is enabled the prompt length and raw response are also logged
-to help troubleshoot unexpected LLM behaviour.
+The prompt length and raw response are always logged to help troubleshoot
+unexpected LLM behaviour.

--- a/smart_price/core/extract_excel.py
+++ b/smart_price/core/extract_excel.py
@@ -8,6 +8,7 @@ from typing import Tuple, Optional, IO, Any
 import pandas as pd
 import logging
 from datetime import datetime
+from pathlib import Path
 from .common_utils import (
     normalize_price,
     select_latest_year_column,
@@ -204,6 +205,14 @@ def extract_from_excel(
         combined["Kisa_Kod"] = None
     if "Malzeme_Kodu" not in combined.columns:
         combined["Malzeme_Kodu"] = None
+    base_name_no_ext = Path(_basename(filepath, filename)).stem
+    combined["Record_Code"] = (
+        base_name_no_ext
+        + "|"
+        + combined["Sayfa"].astype(str)
+        + "|"
+        + (combined.groupby("Sayfa").cumcount() + 1).astype(str)
+    )
     combined.rename(columns={"Malzeme_Adi": "Descriptions"}, inplace=True)
     cols = [
         "Malzeme_Kodu",
@@ -213,5 +222,6 @@ def extract_from_excel(
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Record_Code",
     ]
     return combined[cols].dropna(subset=["Descriptions", "Fiyat"])

--- a/smart_price/parsers.py
+++ b/smart_price/parsers.py
@@ -76,6 +76,7 @@ def parse_df(df: pd.DataFrame) -> pd.DataFrame:
         result["Kisa_Kod"] = None
     if "Malzeme_Kodu" not in result.columns:
         result["Malzeme_Kodu"] = None
+    result["Record_Code"] = None
     result.rename(columns={"Malzeme_Adi": "Descriptions"}, inplace=True)
     cols_out = [
         "Malzeme_Kodu",
@@ -85,6 +86,7 @@ def parse_df(df: pd.DataFrame) -> pd.DataFrame:
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Record_Code",
     ]
     return result[cols_out].dropna(subset=["Descriptions", "Fiyat"])
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -77,6 +77,7 @@ def test_extract_from_excel_basic(tmp_path):
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Record_Code",
     ]
     assert result.columns.tolist() == expected_cols
 
@@ -289,6 +290,7 @@ def test_extract_from_excel_bytesio():
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Record_Code",
     ]
     assert result.columns.tolist() == expected_cols
 
@@ -508,6 +510,7 @@ def test_extract_from_pdf_default_currency(monkeypatch):
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Record_Code",
     ]
     assert result.columns.tolist() == expected_cols
 
@@ -562,6 +565,7 @@ def test_extract_from_pdf_table_headers(monkeypatch):
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Record_Code",
     ]
     assert result.columns.tolist() == expected_cols
 
@@ -724,14 +728,15 @@ def test_llm_debug_files(monkeypatch, tmp_path):
 
     monkeypatch.setattr(pdf_mod.ocr_llm_fallback, "parse", fake_parse)
 
-    monkeypatch.setenv("SMART_PRICE_DEBUG", "1")
     monkeypatch.setenv("SMART_PRICE_DEBUG_DIR", str(tmp_path))
 
     df = extract_from_pdf("dummy.pdf")
 
+    folder = tmp_path / "dummy"
+
     assert not df.empty
-    assert any(p.suffix == ".png" for p in tmp_path.iterdir())
-    assert any(p.name.startswith("llm_response") for p in tmp_path.iterdir())
+    assert any(p.suffix == ".png" for p in folder.iterdir())
+    assert any(p.name.startswith("llm_response") for p in folder.iterdir())
 
 
 def test_extract_from_pdf_llm_sets_page_added(monkeypatch):


### PR DESCRIPTION
## Summary
- enable debug output for every run and store under `LLM_Output_db/<pdf name>`
- record origin info in `Record_Code` column when parsing Excel/PDF files
- keep a short-lived output subdir in `debug_utils`
- update tests for new defaults
- document automatic debug behaviour

## Testing
- `pytest -q`