### PR TITLE
Remove unused imports

### DIFF
--- a/smart_price/core/extract_pdf.py
+++ b/smart_price/core/extract_pdf.py
@@ -11,7 +11,6 @@ import unicodedata
 
 import pandas as pd
 import pdfplumber
-import json
 import time
 from dotenv import load_dotenv
 

--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import json
 import logging
 import os
 from typing import Iterable, Sequence
@@ -17,7 +16,6 @@ import pandas as pd
 import tempfile
 from pathlib import Path
 
-from PIL import Image  # type: ignore
 
 from .common_utils import (
     gpt_clean_text,

--- a/tests/test_page_summary.py
+++ b/tests/test_page_summary.py
@@ -30,7 +30,6 @@ except ModuleNotFoundError:
 if HAS_PANDAS:
     from smart_price.core.extract_pdf import extract_from_pdf
     import smart_price.core.extract_pdf as pdf_mod
-    from smart_price.core import ocr_llm_fallback as fallback_mod
 else:
     extract_from_pdf = None
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -2,7 +2,6 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import types
-import time
 import pytest
 
 # Try to import pandas to see if available
@@ -778,8 +777,6 @@ def test_extract_from_pdf_llm_sets_page_added(monkeypatch):
         return ""
 
     import sys
-    import types
-    import time
 
     pdfplumber_mod = sys.modules.get("pdfplumber")
     monkeypatch.setattr(pdfplumber_mod, "open", fake_open, raising=False)


### PR DESCRIPTION
## Summary
- drop unused imports from extract_pdf and ocr_llm_fallback
- tidy tests by removing extraneous imports
- run `ruff check` to confirm there are no `F401` warnings

## Testing
- `ruff check . | grep -n "F401" || echo "No F401"`