### PR TITLE
Update unit tests for GPT-4o

### DIFF
--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -163,7 +163,7 @@ def test_llm_empty_items_logs_excerpt(monkeypatch):
     result = func(text)
     assert result == []
     assert any('no items parsed by' in msg for msg in logs)
-    assert 'gpt-3.5-turbo' in ''.join(logs)
+    assert 'gpt-4o' in ''.join(logs)
 
 
 def test_llm_prompt_and_clean(monkeypatch):
@@ -182,7 +182,7 @@ def test_llm_prompt_and_clean(monkeypatch):
 
     result = func('sample')
     assert cleaned == ['[{"name":"A","price":"4"}]']
-    assert 'return only' in captured_prompt[0]
+    assert 'Malzeme_Kodu - Fiyat çıkarma asistanısın' in captured_prompt[0]
     assert result == [{
         'Malzeme_Adi': 'A',
         'Fiyat': 4.0,


### PR DESCRIPTION
## Summary
- update `test_llm_extract` expectations to reflect GPT-4o model and new prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6839f9b847dc832fadc7620077df6c39