### PR TITLE
Support underscore product fields in LLM results

### DIFF
--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -312,16 +312,21 @@ def parse(
 
         items = items if isinstance(items, list) else [items]
         for item in items:
+            code = item.get("Malzeme_Kodu") or item.get("Malzeme Kodu")
             descr = item.get("Açıklama")
             price_raw = str(item.get("Fiyat", "")).strip()
+            kutu_adedi = item.get("Kutu_Adedi") or item.get("Kutu Adedi")
+            para_birimi = item.get("Para_Birimi") or item.get("Para Birimi")
+            if para_birimi is None:
+                para_birimi = detect_currency(price_raw)
             page_rows.append(
                 {
-                    "Malzeme_Kodu": item.get("Malzeme Kodu"),
+                    "Malzeme_Kodu": code,
                     "Descriptions": descr,
                     "Fiyat": normalize_price(price_raw),
                     "Birim": item.get("Birim"),
-                    "Kutu_Adedi": item.get("Kutu Adedi"),
-                    "Para_Birimi": detect_currency(price_raw),
+                    "Kutu_Adedi": kutu_adedi,
+                    "Para_Birimi": para_birimi,
                     "Sayfa": idx,
                 }
             )

--- a/tests/test_page_summary.py
+++ b/tests/test_page_summary.py
@@ -78,7 +78,7 @@ def test_ocr_llm_fallback_summary(monkeypatch):
     monkeypatch.setitem(sys.modules, "pdf2image", types.SimpleNamespace(convert_from_path=fake_convert))
 
     contents = [
-        '[{"Malzeme Kodu":"A","Açıklama":"X","Fiyat":"1"}]',
+        '[{"Malzeme_Kodu":"A","Açıklama":"X","Fiyat":"1"}]',
         '[]'
     ]
     def create(**kwargs):


### PR DESCRIPTION
## Summary
- handle underscore and space variants for fields returned by the LLM
- test `parse` page summary with underscore field name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a0a275fec832f956574af04065491