### PR TITLE
Add detailed logging for row counts

### DIFF
--- a/smart_price/core/debug_utils.py
+++ b/smart_price/core/debug_utils.py
@@ -60,3 +60,29 @@ def save_debug_image(prefix: str, page: int, image: Image.Image) -> Optional[Pat
     except Exception as exc:  # pragma: no cover - debug file failures
         logger.debug("debug image write failed for %s: %s", file_path, exc)
     return file_path
+
+
+def log_row_change(
+    file: str,
+    step: str,
+    before_df,
+    after_df,
+    *,
+    reason: str,
+) -> None:
+    """Log row counts before and after a transformation."""
+    before = len(before_df)
+    after = len(after_df)
+    dropped = before - after
+    logger.debug(
+        f"[{file}] {step} sonrası: {after} satır (drop edilen: {dropped} satır)"
+    )
+    logger.debug(f"[{file}] Drop nedeni: {reason}")
+    if dropped > 0:
+        try:
+            diff = before_df.loc[~before_df.index.isin(after_df.index)]
+            logger.debug(
+                f"[{file}] Drop edilen ilk 5 satır: {diff.head().to_dict(orient='records')}"
+            )
+        except Exception as exc:
+            logger.debug(f"[{file}] Dropped rows logging failed: {exc}")

--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -360,7 +360,14 @@ def parse(
         rows.extend(rows_out)
         page_summary.append(summary)
 
+    logger.debug(
+        "[%s] LLM Vision output: %d rows extracted from PDF",
+        pdf_path,
+        len(rows),
+    )
+
     df = pd.DataFrame(rows)
+    logger.debug("[%s] DataFrame oluşturuldu: %d satır", pdf_path, len(df))
     if hasattr(df, "columns") and "Kutu_Adedi" in getattr(df, "columns", []):
         try:
             df["Kutu_Adedi"] = df["Kutu_Adedi"].astype("string")


### PR DESCRIPTION
## Summary
- instrument PDF Vision fallback and Phase-1 extraction with extra debug
- log rows when converting images to DataFrame
- add debug logging for Excel extraction
- trace drops and deduplication in Streamlit merge process
- helper to log row changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a4d61b41c832f9dd59ffaaecef709