### PR TITLE
Simplify merge filtering

### DIFF
--- a/smart_price/streamlit_app.py
+++ b/smart_price/streamlit_app.py
@@ -148,65 +148,20 @@ def merge_files(
 
     master = pd.concat(extracted, ignore_index=True)
     logger.debug("[merge] Raw merged rows: %d", len(master))
-    drop_mask = master[["Descriptions", "Fiyat"]].isna().any(axis=1)
+    master["Fiyat"] = pd.to_numeric(master["Fiyat"], errors="coerce")
+    drop_mask = master[["Malzeme_Kodu", "Fiyat"]].isna().any(axis=1)
     dropped_preview = master[drop_mask].head().to_dict(orient="records")
     before_len = len(master)
-    master.dropna(subset=["Descriptions", "Fiyat"], inplace=True)
+    master.dropna(subset=["Malzeme_Kodu", "Fiyat"], inplace=True)
     logger.debug(
         "[merge] Filter sonrası: %d satır (drop edilen: %d satır)",
         len(master),
         before_len - len(master),
     )
     if before_len != len(master):
-        logger.debug("[merge] Drop nedeni: subset=['Descriptions', 'Fiyat']")
+        logger.debug("[merge] Drop nedeni: subset=['Malzeme_Kodu', 'Fiyat']")
         logger.debug("[merge] Drop edilen ilk 5 satır: %s", dropped_preview)
     master["Descriptions"] = master["Descriptions"].astype(str).str.strip().str.upper()
-    before_len = len(master)
-    empty_preview = master[master["Descriptions"] == ""].head().to_dict(orient="records")
-    master = master[master["Descriptions"] != ""]
-    if before_len != len(master):
-        logger.debug(
-            "[merge] Filter sonrası: %d satır (drop edilen: %d satır)",
-            len(master),
-            before_len - len(master),
-        )
-        logger.debug("[merge] Drop nedeni: boş Description")
-        logger.debug("[merge] Drop edilen ilk 5 satır: %s", empty_preview)
-    master["Fiyat"] = pd.to_numeric(master["Fiyat"], errors="coerce")
-    before_len = len(master)
-    fiyat_na_preview = master[master["Fiyat"].isna()].head().to_dict(orient="records")
-    master.dropna(subset=["Fiyat"], inplace=True)
-    if before_len != len(master):
-        logger.debug(
-            "[merge] Filter sonrası: %d satır (drop edilen: %d satır)",
-            len(master),
-            before_len - len(master),
-        )
-        logger.debug("[merge] Drop nedeni: Fiyat NaN")
-        logger.debug("[merge] Drop edilen ilk 5 satır: %s", fiyat_na_preview)
-    before_len = len(master)
-    dup_mask = master.duplicated(subset=["Malzeme_Kodu", "Fiyat"], keep="last")
-    dup_preview = master[dup_mask].head().to_dict(orient="records")
-    master.drop_duplicates(subset=["Malzeme_Kodu", "Fiyat"], keep="last", inplace=True)
-    logger.debug("[merge] Deduplication: subset=['Malzeme_Kodu', 'Fiyat']")
-    if before_len != len(master):
-        logger.debug(
-            "[merge] Filter sonrası: %d satır (drop edilen: %d satır)",
-            len(master),
-            before_len - len(master),
-        )
-        logger.debug("[merge] Drop edilen ilk 5 satır: %s", dup_preview)
-    before_len = len(master)
-    low_price_preview = master[master["Fiyat"] <= 0.01].head().to_dict(orient="records")
-    master = master[master["Fiyat"] > 0.01]
-    if before_len != len(master):
-        logger.debug(
-            "[merge] Filter sonrası: %d satır (drop edilen: %d satır)",
-            len(master),
-            before_len - len(master),
-        )
-        logger.debug("[merge] Drop nedeni: Fiyat > 0.01")
-        logger.debug("[merge] Drop edilen ilk 5 satır: %s", low_price_preview)
     master.sort_values(by="Descriptions", inplace=True)
     if "Kisa_Kod" in master.columns:
         master["Kisa_Kod"] = master["Kisa_Kod"].astype(str)

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -728,8 +728,8 @@ def test_merge_files_dedup_by_code_and_price(monkeypatch):
     uploads = [FakeUpload(name) for name in df_map]
     result = streamlit_app.merge_files(uploads)
 
-    assert len(result) == 2
-    assert set(result["Fiyat"]) == {1.0, 2.0}
+    assert len(result) == 3
+    assert list(result["Fiyat"]) == [1.0, 1.0, 2.0]
 
 
 def test_llm_debug_files(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- filter merged data only on mandatory `Malzeme_Kodu` and `Fiyat`
- adjust test for new behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a555dbb64832fb4e40855525fca72