### PR TITLE
Add sales query interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,4 @@ where = ["smart_price"]
 [project.scripts]
 smart-price-parser = "smart_price.price_parser:main"
 smart-price-app = "smart_price.streamlit_app:cli"
+smart-price-sales = "sales_app.streamlit_app:cli"

--- a/run_sales_app.py
+++ b/run_sales_app.py
@@ -1,0 +1,8 @@
+import os
+import pathlib
+from streamlit.web import cli as stcli
+
+if __name__ == "__main__":
+    pkg_root = pathlib.Path(__file__).parent
+    st_file = pkg_root / "sales_app" / "streamlit_app.py"
+    stcli.main(["streamlit", "run", str(st_file)])

--- a/sales_app/README.md
+++ b/sales_app/README.md
@@ -1,0 +1,14 @@
+# Sales Query Application
+
+This Streamlit app provides sales staff with an easy interface to search the latest
+pricing information. The app fetches the master dataset directly from GitHub on
+startup so that users always work with the most up to date data.
+
+Run locally with:
+
+```bash
+python run_sales_app.py
+```
+
+Set the `MASTER_DATA_URL` environment variable to override the default master
+dataset location.

--- a/sales_app/streamlit_app.py
+++ b/sales_app/streamlit_app.py
@@ -1,0 +1,76 @@
+"""Streamlit application for querying the master price dataset."""
+import io
+import os
+import logging
+
+import pandas as pd
+import requests
+import streamlit as st
+
+logger = logging.getLogger("sales_app")
+
+DEFAULT_DATA_URL = (
+    "https://raw.githubusercontent.com/USERNAME/Smart_Price/master/master_dataset.xlsx"
+)
+
+
+def _load_dataset(url: str) -> pd.DataFrame:
+    """Download the Excel master dataset from ``url``."""
+    logger.info("Fetching master data from %s", url)
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return pd.read_excel(io.BytesIO(resp.content))
+
+
+@st.cache_data(show_spinner=True)
+def get_master_dataset() -> pd.DataFrame:
+    """Return the master dataset downloaded from GitHub."""
+    url = os.getenv("MASTER_DATA_URL", DEFAULT_DATA_URL)
+    try:
+        df = _load_dataset(url)
+    except Exception as exc:
+        logger.error("Failed to fetch master dataset: %s", exc)
+        return pd.DataFrame()
+    return df
+
+
+def search_page(df: pd.DataFrame) -> None:
+    st.header("Master Veride Ara")
+    if df.empty:
+        st.error("Veri yüklenemedi.")
+        return
+
+    query = st.text_input("Malzeme kodu veya adı")
+    brand = st.selectbox("Marka", [""] + sorted(df["Marka"].dropna().unique().tolist())) if "Marka" in df.columns else ""
+    year = st.selectbox("Yıl", [""] + sorted(df["Yil"].dropna().unique().tolist())) if "Yil" in df.columns else ""
+
+    filtered = df
+    if query:
+        filtered = filtered[filtered["Descriptions"].str.contains(query, case=False, na=False) |
+                              filtered["Malzeme_Kodu"].str.contains(query, case=False, na=False)]
+    if brand:
+        filtered = filtered[filtered["Marka"] == brand]
+    if year:
+        filtered = filtered[filtered["Yil"] == year]
+
+    st.write(f"{len(filtered)} kayıt bulundu")
+    st.dataframe(filtered)
+
+
+def main() -> None:
+    st.sidebar.title("Smart Price Sales")
+    df = get_master_dataset()
+    search_page(df)
+
+
+def cli() -> None:
+    """Entry point used by the console script."""
+    from streamlit.web import cli as stcli
+    import sys
+
+    sys.argv = ["streamlit", "run", __file__]
+    stcli.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a separate `sales_app` folder for phase 2
- new Streamlit UI downloads master price data from GitHub each run
- expose entry point `smart-price-sales`
- add `run_sales_app.py` helper script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b0b34d6b8832f846aa26523fbd485