### PR TITLE
Add GitHub upload helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ The log records extra details to help trace each step:
 - and the first items parsed from the response.
 - per-page debug files stored under `LLM_Output_db/<PDF adı>` (set
   `SMART_PRICE_DEBUG_DIR` to override the location)
+- set `GITHUB_REPO` and `GITHUB_TOKEN` to automatically push each debug
+  directory to the given repository under `LLM_Output_db/` (optionally specify
+  `GITHUB_BRANCH`)
 
 ## Troubleshooting
 

--- a/smart_price/core/extract_pdf.py
+++ b/smart_price/core/extract_pdf.py
@@ -37,6 +37,7 @@ from .extract_excel import POSSIBLE_CODE_HEADERS
 from . import ocr_llm_fallback
 from pathlib import Path
 from .debug_utils import save_debug, set_output_subdir
+from .github_upload import upload_folder
 
 MIN_CODE_RATIO = 0.70
 MIN_ROWS_PARSER = 500
@@ -642,5 +643,7 @@ def extract_from_pdf(
     if hasattr(result_df, "__dict__"):
         object.__setattr__(result_df, "page_summary", page_summary)
     cleanup()
+    debug_dir = Path(os.getenv("SMART_PRICE_DEBUG_DIR", "LLM_Output_db")) / output_stem
     set_output_subdir(None)
+    upload_folder(debug_dir)
     return result_df

--- a/smart_price/core/github_upload.py
+++ b/smart_price/core/github_upload.py
@@ -1,0 +1,63 @@
+import base64
+import json
+import logging
+import os
+from pathlib import Path
+from urllib import request, error
+
+logger = logging.getLogger("smart_price")
+
+
+def _api_request(method: str, url: str, token: str, data: dict | None = None) -> dict:
+    req = request.Request(url, method=method)
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    if data is not None:
+        payload = json.dumps(data).encode("utf-8")
+        req.add_header("Content-Type", "application/json")
+        req.data = payload
+    try:
+        with request.urlopen(req) as resp:
+            text = resp.read().decode("utf-8")
+        return json.loads(text) if text else {}
+    except error.HTTPError as exc:  # pragma: no cover - network errors
+        logger.debug("GitHub API error for %s: %s", url, exc)
+        raise
+    except Exception as exc:  # pragma: no cover - unexpected failures
+        logger.debug("GitHub request failed for %s: %s", url, exc)
+        raise
+
+
+def upload_folder(path: Path) -> None:
+    """Upload ``path`` to a GitHub repository under ``LLM_Output_db``.
+
+    Requires ``GITHUB_REPO`` and ``GITHUB_TOKEN`` environment variables. Set
+    ``GITHUB_BRANCH`` to push to a branch other than ``main``.
+    """
+    repo = os.getenv("GITHUB_REPO")
+    token = os.getenv("GITHUB_TOKEN")
+    branch = os.getenv("GITHUB_BRANCH", "main")
+    if not repo or not token:
+        logger.debug("GitHub repo or token not configured")
+        return
+
+    for file_path in path.rglob("*"):
+        if not file_path.is_file():
+            continue
+        repo_path = Path("LLM_Output_db") / file_path.relative_to(path)
+        url = f"https://api.github.com/repos/{repo}/contents/{repo_path.as_posix()}"
+        with open(file_path, "rb") as fh:
+            content = base64.b64encode(fh.read()).decode("ascii")
+        try:
+            resp = _api_request("GET", f"{url}?ref={branch}", token)
+            sha = resp.get("sha")
+        except Exception:
+            sha = None
+        data = {"message": f"Add {repo_path}", "content": content, "branch": branch}
+        if sha:
+            data["sha"] = sha
+        try:
+            _api_request("PUT", url, token, data)
+        except Exception:
+            continue
+

--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -27,6 +27,7 @@ from .common_utils import (
     safe_json_parse,
 )
 from .debug_utils import save_debug, save_debug_image, set_output_subdir
+from .github_upload import upload_folder
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     from PIL import Image  # noqa: F401
@@ -386,6 +387,8 @@ def parse(
         object.__setattr__(df, "page_summary", page_summary)
     total_dur = time.time() - total_start
     logger.info("Finished %s with %d rows in %.2fs", pdf_path, len(df), total_dur)
+    debug_dir = Path(os.getenv("SMART_PRICE_DEBUG_DIR", "LLM_Output_db")) / output_name
     set_output_subdir(None)
+    upload_folder(debug_dir)
     return df
 


### PR DESCRIPTION
## Summary
- create `github_upload` module for committing debug files to GitHub
- upload debug folders after PDF parsing
- document GitHub environment variables in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b1ff3e028832fa547d0a155ebee6f