### PR TITLE
Update sales app DB handling

### DIFF
--- a/sales_app/README.md
+++ b/sales_app/README.md
@@ -2,7 +2,8 @@
 
 This Streamlit app provides sales staff with an easy interface to search the latest
 pricing information. The app fetches the master dataset directly from GitHub on
-startup so that users always work with the most up to date data.
+startup so that users always work with the most up to date data. The dataset is
+stored in a SQLite database (`master.db`).
 
 Run locally with:
 
@@ -10,5 +11,6 @@ Run locally with:
 python run_sales_app.py
 ```
 
-Set the `MASTER_DATA_URL` environment variable to override the default master
-dataset location.
+Set the `MASTER_DB_URL` environment variable to override the default database
+location. The images displayed for each record are downloaded from GitHub as
+well. Use `IMAGE_BASE_URL` to customise the base URL for these images.


### PR DESCRIPTION
## Summary
- load the master data from a SQLite database
- allow a record to be selected and show the corresponding page image
- document new configuration variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b28a3c304832f8274b1970334a9ee