### PR TITLE
Add configuration loader module

### DIFF
--- a/smart_price/config.py
+++ b/smart_price/config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv, find_dotenv
+
+# Repository root is two levels up from this file
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Default locations matching the repository layout
+_DEFAULT_MASTER_DB_PATH = _REPO_ROOT / "master.db"
+_DEFAULT_IMAGE_DIR = _REPO_ROOT / "images"
+_DEFAULT_SALES_APP_DIR = _REPO_ROOT / "sales_app"
+_DEFAULT_PRICE_APP_DIR = _REPO_ROOT / "smart_price"
+_DEFAULT_DEBUG_DIR = _REPO_ROOT / "LLM_Output_db"
+
+# Public configuration variables (will be initialised by ``load_config``)
+MASTER_DB_PATH: Path = _DEFAULT_MASTER_DB_PATH
+IMAGE_DIR: Path = _DEFAULT_IMAGE_DIR
+SALES_APP_DIR: Path = _DEFAULT_SALES_APP_DIR
+PRICE_APP_DIR: Path = _DEFAULT_PRICE_APP_DIR
+DEBUG_DIR: Path = _DEFAULT_DEBUG_DIR
+
+__all__ = [
+    "MASTER_DB_PATH",
+    "IMAGE_DIR",
+    "SALES_APP_DIR",
+    "PRICE_APP_DIR",
+    "DEBUG_DIR",
+    "load_config",
+]
+
+
+def load_config() -> None:
+    """Load configuration from ``.env`` and ``config.json`` if present."""
+    dotenv_file = find_dotenv(usecwd=True)
+    if dotenv_file:
+        load_dotenv(dotenv_file)
+
+    config_file = _REPO_ROOT / "config.json"
+    config: dict[str, str] = {}
+    if config_file.exists():
+        try:
+            config = json.loads(config_file.read_text(encoding="utf-8"))
+        except Exception:
+            config = {}
+
+    def _get(name: str, default: Path) -> Path:
+        return Path(os.getenv(name, config.get(name, str(default))))
+
+    global MASTER_DB_PATH, IMAGE_DIR, SALES_APP_DIR, PRICE_APP_DIR, DEBUG_DIR
+
+    MASTER_DB_PATH = _get("MASTER_DB_PATH", _DEFAULT_MASTER_DB_PATH)
+    IMAGE_DIR = _get("IMAGE_DIR", _DEFAULT_IMAGE_DIR)
+    SALES_APP_DIR = _get("SALES_APP_DIR", _DEFAULT_SALES_APP_DIR)
+    PRICE_APP_DIR = _get("PRICE_APP_DIR", _DEFAULT_PRICE_APP_DIR)
+    DEBUG_DIR = _get("DEBUG_DIR", _DEFAULT_DEBUG_DIR)
+
+
+# Initialise configuration on import
+load_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,52 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+# Provide a stub for python-dotenv if not installed
+dotenv_stub = sys.modules.get('dotenv', types.ModuleType('dotenv'))
+if not hasattr(dotenv_stub, 'load_dotenv'):
+    dotenv_stub.load_dotenv = lambda *_args, **_kw: None
+if not hasattr(dotenv_stub, 'find_dotenv'):
+    dotenv_stub.find_dotenv = lambda *_args, **_kw: ''
+sys.modules['dotenv'] = dotenv_stub
+
+import smart_price.config as cfg
+
+
+def test_defaults(monkeypatch):
+    dotenv_stub = types.ModuleType('dotenv')
+    dotenv_stub.load_dotenv = lambda *_a, **_k: None
+    dotenv_stub.find_dotenv = lambda *_a, **_k: ''
+    monkeypatch.setitem(sys.modules, 'dotenv', dotenv_stub)
+    for name in ("MASTER_DB_PATH", "IMAGE_DIR", "SALES_APP_DIR", "PRICE_APP_DIR", "DEBUG_DIR"):
+        monkeypatch.delenv(name, raising=False)
+    importlib.reload(cfg)
+    root = Path(__file__).resolve().parent.parent
+    assert cfg.MASTER_DB_PATH == root / "master.db"
+    assert cfg.IMAGE_DIR == root / "images"
+    assert cfg.SALES_APP_DIR == root / "sales_app"
+    assert cfg.PRICE_APP_DIR == root / "smart_price"
+    assert cfg.DEBUG_DIR == root / "LLM_Output_db"
+
+
+def test_env_and_config_overrides(tmp_path, monkeypatch):
+    dotenv_stub = types.ModuleType('dotenv')
+    dotenv_stub.load_dotenv = lambda *_a, **_k: None
+    dotenv_stub.find_dotenv = lambda *_a, **_k: ''
+    monkeypatch.setitem(sys.modules, 'dotenv', dotenv_stub)
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"IMAGE_DIR": "imx"}')
+    monkeypatch.setattr(cfg, "_REPO_ROOT", tmp_path)
+    monkeypatch.setenv("MASTER_DB_PATH", str(tmp_path / "db.sqlite"))
+    monkeypatch.setenv("DEBUG_DIR", str(tmp_path / "dbg"))
+    monkeypatch.setenv("IMAGE_DIR", str(tmp_path / "img_env"))
+    monkeypatch.setenv("SALES_APP_DIR", str(tmp_path / "sales"))
+    monkeypatch.setenv("PRICE_APP_DIR", str(tmp_path / "price"))
+    importlib.reload(cfg)
+    cfg.load_config()
+    assert cfg.MASTER_DB_PATH == tmp_path / "db.sqlite"
+    assert cfg.IMAGE_DIR == tmp_path / "img_env"
+    assert cfg.SALES_APP_DIR == tmp_path / "sales"
+    assert cfg.PRICE_APP_DIR == tmp_path / "price"
+    assert cfg.DEBUG_DIR == tmp_path / "dbg"


### PR DESCRIPTION
## Summary
- implement new `smart_price.config` module
- support loading `.env` and optional `config.json`
- expose path constants such as `MASTER_DB_PATH` and `DEBUG_DIR`
- add tests for configuration defaults and overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b30822214832f92a4dc2b2dccb615