### PR TITLE
Use config path for master dataset

### DIFF
--- a/smart_price/streamlit_app.py
+++ b/smart_price/streamlit_app.py
@@ -16,6 +16,7 @@ from typing import Callable, Optional
 
 from smart_price.core.extract_excel import extract_from_excel
 from smart_price.core.extract_pdf import extract_from_pdf, MIN_CODE_RATIO
+from smart_price import config
 from smart_price.core.logger import init_logging
 
 logger = logging.getLogger("smart_price")
@@ -64,17 +65,9 @@ def resource_path(relative: str) -> str:
     return str(Path(base_path) / relative)
 
 
-DATA_FILE = "master_dataset.xlsx"
-
-
 def get_master_dataset_path() -> str:
-    """Locate master dataset either next to the executable or inside bundle."""
-    if os.path.exists(DATA_FILE):
-        return DATA_FILE
-    bundled = resource_path(DATA_FILE)
-    if os.path.exists(bundled):
-        return bundled
-    return DATA_FILE
+    """Return the configured master dataset path."""
+    return str(config.MASTER_DB_PATH)
 
 
 def extract_from_excel_file(
@@ -172,7 +165,7 @@ def merge_files(
 
 def save_master_dataset(df: pd.DataFrame, mode: str = "Yeni fiyat listesi") -> str:
     """Save ``df`` into the master dataset file handling update logic."""
-    data_path = os.path.abspath(get_master_dataset_path())
+    data_path = os.path.abspath(str(config.MASTER_DB_PATH))
     existing = pd.DataFrame()
     if os.path.exists(data_path):
         try:

--- a/tests/test_save_master_dataset.py
+++ b/tests/test_save_master_dataset.py
@@ -43,6 +43,7 @@ def test_save_master_new(tmp_path, monkeypatch):
     import pandas as pd
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(streamlit_app.config, "MASTER_DB_PATH", tmp_path / "master_dataset.xlsx")
     df = pd.DataFrame({
         'Malzeme_Kodu': ['A1'],
         'Descriptions': ['Item'],
@@ -63,6 +64,7 @@ def test_save_master_update(tmp_path, monkeypatch):
     import pandas as pd
 
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(streamlit_app.config, "MASTER_DB_PATH", tmp_path / "master_dataset.xlsx")
     master = pd.DataFrame({
         'Malzeme_Kodu': ['X1', 'Y1'],
         'Descriptions': ['Old', 'Keep'],


### PR DESCRIPTION
## Summary
- use config.MASTER_DB_PATH in the Streamlit app
- adjust tests to patch the new dataset path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b352f071c832f8db44ce6e18b58a4