### PR TITLE
Use config for CLI defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Extract prices from files on the command line and save the merged result using t
 smart-price-parser data/list.xlsx another.pdf -o merged_prices.xlsx
 ```
 
+The parser writes its results to `output/` by default. Set `OUTPUT_DIR` to
+change this location or specify `OUTPUT_EXCEL`, `OUTPUT_DB` and `OUTPUT_LOG`
+to override each individual path.
+
 ### Running the Streamlit interface
 
 Launch the web UI locally with:

--- a/smart_price/config.py
+++ b/smart_price/config.py
@@ -15,6 +15,10 @@ _DEFAULT_IMAGE_DIR = _REPO_ROOT / "images"
 _DEFAULT_SALES_APP_DIR = _REPO_ROOT / "sales_app"
 _DEFAULT_PRICE_APP_DIR = _REPO_ROOT / "smart_price"
 _DEFAULT_DEBUG_DIR = _REPO_ROOT / "LLM_Output_db"
+_DEFAULT_OUTPUT_DIR = _REPO_ROOT / "output"
+_DEFAULT_OUTPUT_EXCEL = _DEFAULT_OUTPUT_DIR / "merged_prices.xlsx"
+_DEFAULT_OUTPUT_DB = _DEFAULT_OUTPUT_DIR / "fiyat_listesi.db"
+_DEFAULT_OUTPUT_LOG = _DEFAULT_OUTPUT_DIR / "source_log.csv"
 
 # Public configuration variables (will be initialised by ``load_config``)
 MASTER_DB_PATH: Path = _DEFAULT_MASTER_DB_PATH
@@ -22,6 +26,10 @@ IMAGE_DIR: Path = _DEFAULT_IMAGE_DIR
 SALES_APP_DIR: Path = _DEFAULT_SALES_APP_DIR
 PRICE_APP_DIR: Path = _DEFAULT_PRICE_APP_DIR
 DEBUG_DIR: Path = _DEFAULT_DEBUG_DIR
+OUTPUT_DIR: Path = _DEFAULT_OUTPUT_DIR
+OUTPUT_EXCEL: Path = _DEFAULT_OUTPUT_EXCEL
+OUTPUT_DB: Path = _DEFAULT_OUTPUT_DB
+OUTPUT_LOG: Path = _DEFAULT_OUTPUT_LOG
 
 __all__ = [
     "MASTER_DB_PATH",
@@ -29,6 +37,10 @@ __all__ = [
     "SALES_APP_DIR",
     "PRICE_APP_DIR",
     "DEBUG_DIR",
+    "OUTPUT_DIR",
+    "OUTPUT_EXCEL",
+    "OUTPUT_DB",
+    "OUTPUT_LOG",
     "load_config",
 ]
 
@@ -50,13 +62,18 @@ def load_config() -> None:
     def _get(name: str, default: Path) -> Path:
         return Path(os.getenv(name, config.get(name, str(default))))
 
-    global MASTER_DB_PATH, IMAGE_DIR, SALES_APP_DIR, PRICE_APP_DIR, DEBUG_DIR
+    global MASTER_DB_PATH, IMAGE_DIR, SALES_APP_DIR, PRICE_APP_DIR, DEBUG_DIR, OUTPUT_DIR, OUTPUT_EXCEL, OUTPUT_DB, OUTPUT_LOG
 
     MASTER_DB_PATH = _get("MASTER_DB_PATH", _DEFAULT_MASTER_DB_PATH)
     IMAGE_DIR = _get("IMAGE_DIR", _DEFAULT_IMAGE_DIR)
     SALES_APP_DIR = _get("SALES_APP_DIR", _DEFAULT_SALES_APP_DIR)
     PRICE_APP_DIR = _get("PRICE_APP_DIR", _DEFAULT_PRICE_APP_DIR)
     DEBUG_DIR = _get("DEBUG_DIR", _DEFAULT_DEBUG_DIR)
+
+    OUTPUT_DIR = _get("OUTPUT_DIR", _DEFAULT_OUTPUT_DIR)
+    OUTPUT_EXCEL = _get("OUTPUT_EXCEL", OUTPUT_DIR / "merged_prices.xlsx")
+    OUTPUT_DB = _get("OUTPUT_DB", OUTPUT_DIR / "fiyat_listesi.db")
+    OUTPUT_LOG = _get("OUTPUT_LOG", OUTPUT_DIR / "source_log.csv")
 
 
 # Initialise configuration on import

--- a/smart_price/price_parser.py
+++ b/smart_price/price_parser.py
@@ -8,6 +8,8 @@ import pytesseract
 import shutil
 from dotenv import load_dotenv
 
+from smart_price import config
+
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".env"))
 load_dotenv(dotenv_path=project_root)
 
@@ -57,12 +59,31 @@ def _configure_tesseract() -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Extract prices from Excel and PDF files")
-    parser.add_argument('files', nargs='*', help='Input Excel or PDF files')
-    parser.add_argument('-o', '--output', default=os.path.join('output', 'merged_prices.xlsx'), help='Output Excel file path')
-    parser.add_argument('--db', default=os.path.join('output', 'fiyat_listesi.db'), help='Output SQLite DB path')
-    parser.add_argument('--log', default=os.path.join('output', 'source_log.csv'), help='CSV log path')
-    parser.add_argument('--show-log', action='store_true', help='Display the most recent log and exit')
+    parser = argparse.ArgumentParser(
+        description="Extract prices from Excel and PDF files"
+    )
+    parser.add_argument("files", nargs="*", help="Input Excel or PDF files")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=str(config.OUTPUT_EXCEL),
+        help="Output Excel file path",
+    )
+    parser.add_argument(
+        "--db",
+        default=str(config.OUTPUT_DB),
+        help="Output SQLite DB path",
+    )
+    parser.add_argument(
+        "--log",
+        default=str(config.OUTPUT_LOG),
+        help="CSV log path",
+    )
+    parser.add_argument(
+        "--show-log",
+        action="store_true",
+        help="Display the most recent log and exit",
+    )
     return parser.parse_args()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,17 @@ def test_defaults(monkeypatch):
     dotenv_stub.load_dotenv = lambda *_a, **_k: None
     dotenv_stub.find_dotenv = lambda *_a, **_k: ''
     monkeypatch.setitem(sys.modules, 'dotenv', dotenv_stub)
-    for name in ("MASTER_DB_PATH", "IMAGE_DIR", "SALES_APP_DIR", "PRICE_APP_DIR", "DEBUG_DIR"):
+    for name in (
+        "MASTER_DB_PATH",
+        "IMAGE_DIR",
+        "SALES_APP_DIR",
+        "PRICE_APP_DIR",
+        "DEBUG_DIR",
+        "OUTPUT_DIR",
+        "OUTPUT_EXCEL",
+        "OUTPUT_DB",
+        "OUTPUT_LOG",
+    ):
         monkeypatch.delenv(name, raising=False)
     importlib.reload(cfg)
     root = Path(__file__).resolve().parent.parent
@@ -28,6 +38,10 @@ def test_defaults(monkeypatch):
     assert cfg.SALES_APP_DIR == root / "sales_app"
     assert cfg.PRICE_APP_DIR == root / "smart_price"
     assert cfg.DEBUG_DIR == root / "LLM_Output_db"
+    assert cfg.OUTPUT_DIR == root / "output"
+    assert cfg.OUTPUT_EXCEL == root / "output" / "merged_prices.xlsx"
+    assert cfg.OUTPUT_DB == root / "output" / "fiyat_listesi.db"
+    assert cfg.OUTPUT_LOG == root / "output" / "source_log.csv"
 
 
 def test_env_and_config_overrides(tmp_path, monkeypatch):
@@ -43,6 +57,10 @@ def test_env_and_config_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("IMAGE_DIR", str(tmp_path / "img_env"))
     monkeypatch.setenv("SALES_APP_DIR", str(tmp_path / "sales"))
     monkeypatch.setenv("PRICE_APP_DIR", str(tmp_path / "price"))
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path / "out"))
+    monkeypatch.setenv("OUTPUT_EXCEL", str(tmp_path / "out" / "m.xlsx"))
+    monkeypatch.setenv("OUTPUT_DB", str(tmp_path / "out" / "db.sqlite"))
+    monkeypatch.setenv("OUTPUT_LOG", str(tmp_path / "out" / "log.csv"))
     importlib.reload(cfg)
     cfg.load_config()
     assert cfg.MASTER_DB_PATH == tmp_path / "db.sqlite"
@@ -50,3 +68,7 @@ def test_env_and_config_overrides(tmp_path, monkeypatch):
     assert cfg.SALES_APP_DIR == tmp_path / "sales"
     assert cfg.PRICE_APP_DIR == tmp_path / "price"
     assert cfg.DEBUG_DIR == tmp_path / "dbg"
+    assert cfg.OUTPUT_DIR == tmp_path / "out"
+    assert cfg.OUTPUT_EXCEL == tmp_path / "out" / "m.xlsx"
+    assert cfg.OUTPUT_DB == tmp_path / "out" / "db.sqlite"
+    assert cfg.OUTPUT_LOG == tmp_path / "out" / "log.csv"


### PR DESCRIPTION
## Summary
- add output paths to config
- set parser defaults from config
- document new environment vars in README
- extend config tests for new options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b366492f0832fb39fcc54c985f070