### PR TITLE
Improve dotenv path handling

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -1,11 +1,16 @@
 import os
 import sys
 import pathlib
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv, find_dotenv
+except ImportError:  # pragma: no cover - support missing find_dotenv
+    from dotenv import load_dotenv
+
+    def find_dotenv() -> str:
+        return ""
 from streamlit.web import cli as stcli
 
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".env"))
-load_dotenv(dotenv_path=project_root)
+load_dotenv(dotenv_path=find_dotenv())
 
 if __name__ == "__main__":
     pkg_root = pathlib.Path(__file__).parent

--- a/smart_price/core/extract_pdf.py
+++ b/smart_price/core/extract_pdf.py
@@ -12,12 +12,18 @@ import unicodedata
 import pandas as pd
 import pdfplumber
 import time
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv, find_dotenv
+except ImportError:  # pragma: no cover - support missing find_dotenv
+    from dotenv import load_dotenv
+
+    def find_dotenv() -> str:
+        return ""
 
 try:
-    load_dotenv("../..")
+    load_dotenv(dotenv_path=find_dotenv())
 except TypeError:  # pragma: no cover - allow stub without args
-    load_dotenv()
+    load_dotenv(dotenv_path=find_dotenv())
 
 # Optional OCR dependencies are imported lazily within extract_from_pdf
 import re

--- a/smart_price/core/ocr_llm_fallback.py
+++ b/smart_price/core/ocr_llm_fallback.py
@@ -7,12 +7,18 @@ import time
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Iterable, Sequence, TYPE_CHECKING
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv, find_dotenv
+except ImportError:  # pragma: no cover - support missing find_dotenv
+    from dotenv import load_dotenv
+
+    def find_dotenv() -> str:
+        return ""
 
 try:
-    load_dotenv("../..")
+    load_dotenv(dotenv_path=find_dotenv())
 except TypeError:  # pragma: no cover - allow stub without args
-    load_dotenv()
+    load_dotenv(dotenv_path=find_dotenv())
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- make `run_app.py` use `find_dotenv()` to locate `.env`
- load `.env` automatically in `extract_pdf` and `ocr_llm_fallback`
- keep working if `find_dotenv` is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b3c70ac98832f9835a26f6816ab2e