### PR TITLE
Allow base repo override for demo data

### DIFF
--- a/sales_app/streamlit_app.py
+++ b/sales_app/streamlit_app.py
@@ -9,14 +9,9 @@ import pandas as pd
 import requests
 import streamlit as st
 
-logger = logging.getLogger("sales_app")
+from smart_price.config import DEFAULT_DB_URL, DEFAULT_IMAGE_BASE_URL
 
-DEFAULT_DB_URL = (
-    "https://raw.githubusercontent.com/USERNAME/Smart_Price/master/master.db"
-)
-DEFAULT_IMAGE_BASE_URL = (
-    "https://raw.githubusercontent.com/USERNAME/Smart_Price/master"
-)
+logger = logging.getLogger("sales_app")
 
 
 def _load_dataset(url: str) -> pd.DataFrame:

--- a/smart_price/config.py
+++ b/smart_price/config.py
@@ -22,6 +22,11 @@ _DEFAULT_OUTPUT_LOG = _DEFAULT_OUTPUT_DIR / "source_log.csv"
 _DEFAULT_TESSERACT_CMD = Path(r"D:\\Program Files\\Tesseract-OCR\\tesseract.exe")
 _DEFAULT_TESSDATA_PREFIX = Path(r"D:\\Program Files\\Tesseract-OCR\\tessdata")
 
+# Default remote repository for the public demo data
+_DEFAULT_BASE_REPO_URL = (
+    "https://raw.githubusercontent.com/USERNAME/Smart_Price/master"
+)
+
 # Public configuration variables (will be initialised by ``load_config``)
 MASTER_DB_PATH: Path = _DEFAULT_MASTER_DB_PATH
 IMAGE_DIR: Path = _DEFAULT_IMAGE_DIR
@@ -34,6 +39,9 @@ OUTPUT_DB: Path = _DEFAULT_OUTPUT_DB
 OUTPUT_LOG: Path = _DEFAULT_OUTPUT_LOG
 TESSERACT_CMD: Path = _DEFAULT_TESSERACT_CMD
 TESSDATA_PREFIX: Path = _DEFAULT_TESSDATA_PREFIX
+BASE_REPO_URL: str = _DEFAULT_BASE_REPO_URL
+DEFAULT_DB_URL: str = f"{BASE_REPO_URL}/master.db"
+DEFAULT_IMAGE_BASE_URL: str = BASE_REPO_URL
 
 __all__ = [
     "MASTER_DB_PATH",
@@ -47,6 +55,9 @@ __all__ = [
     "OUTPUT_LOG",
     "TESSERACT_CMD",
     "TESSDATA_PREFIX",
+    "BASE_REPO_URL",
+    "DEFAULT_DB_URL",
+    "DEFAULT_IMAGE_BASE_URL",
     "load_config",
 ]
 
@@ -68,7 +79,10 @@ def load_config() -> None:
     def _get(name: str, default: Path) -> Path:
         return Path(os.getenv(name, config.get(name, str(default))))
 
-    global MASTER_DB_PATH, IMAGE_DIR, SALES_APP_DIR, PRICE_APP_DIR, DEBUG_DIR, OUTPUT_DIR, OUTPUT_EXCEL, OUTPUT_DB, OUTPUT_LOG, TESSERACT_CMD, TESSDATA_PREFIX
+    def _get_str(name: str, default: str) -> str:
+        return os.getenv(name, config.get(name, default))
+
+    global MASTER_DB_PATH, IMAGE_DIR, SALES_APP_DIR, PRICE_APP_DIR, DEBUG_DIR, OUTPUT_DIR, OUTPUT_EXCEL, OUTPUT_DB, OUTPUT_LOG, TESSERACT_CMD, TESSDATA_PREFIX, BASE_REPO_URL, DEFAULT_DB_URL, DEFAULT_IMAGE_BASE_URL
 
     MASTER_DB_PATH = _get("MASTER_DB_PATH", _DEFAULT_MASTER_DB_PATH)
     IMAGE_DIR = _get("IMAGE_DIR", _DEFAULT_IMAGE_DIR)
@@ -82,6 +96,10 @@ def load_config() -> None:
     OUTPUT_LOG = _get("OUTPUT_LOG", OUTPUT_DIR / "source_log.csv")
     TESSERACT_CMD = _get("TESSERACT_CMD", _DEFAULT_TESSERACT_CMD)
     TESSDATA_PREFIX = _get("TESSDATA_PREFIX", _DEFAULT_TESSDATA_PREFIX)
+
+    BASE_REPO_URL = _get_str("BASE_REPO_URL", _DEFAULT_BASE_REPO_URL)
+    DEFAULT_DB_URL = f"{BASE_REPO_URL}/master.db"
+    DEFAULT_IMAGE_BASE_URL = BASE_REPO_URL
 
 
 # Initialise configuration on import

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ def test_defaults(monkeypatch):
         "OUTPUT_EXCEL",
         "OUTPUT_DB",
         "OUTPUT_LOG",
+        "BASE_REPO_URL",
     ):
         monkeypatch.delenv(name, raising=False)
     importlib.reload(cfg)
@@ -42,6 +43,9 @@ def test_defaults(monkeypatch):
     assert cfg.OUTPUT_EXCEL == root / "output" / "merged_prices.xlsx"
     assert cfg.OUTPUT_DB == root / "output" / "fiyat_listesi.db"
     assert cfg.OUTPUT_LOG == root / "output" / "source_log.csv"
+    assert cfg.BASE_REPO_URL.endswith("Smart_Price/master")
+    assert cfg.DEFAULT_DB_URL == f"{cfg.BASE_REPO_URL}/master.db"
+    assert cfg.DEFAULT_IMAGE_BASE_URL == cfg.BASE_REPO_URL
 
 
 def test_env_and_config_overrides(tmp_path, monkeypatch):
@@ -61,6 +65,7 @@ def test_env_and_config_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("OUTPUT_EXCEL", str(tmp_path / "out" / "m.xlsx"))
     monkeypatch.setenv("OUTPUT_DB", str(tmp_path / "out" / "db.sqlite"))
     monkeypatch.setenv("OUTPUT_LOG", str(tmp_path / "out" / "log.csv"))
+    monkeypatch.setenv("BASE_REPO_URL", "http://example.com/repo")
     importlib.reload(cfg)
     cfg.load_config()
     assert cfg.MASTER_DB_PATH == tmp_path / "db.sqlite"
@@ -72,3 +77,6 @@ def test_env_and_config_overrides(tmp_path, monkeypatch):
     assert cfg.OUTPUT_EXCEL == tmp_path / "out" / "m.xlsx"
     assert cfg.OUTPUT_DB == tmp_path / "out" / "db.sqlite"
     assert cfg.OUTPUT_LOG == tmp_path / "out" / "log.csv"
+    assert cfg.BASE_REPO_URL == "http://example.com/repo"
+    assert cfg.DEFAULT_DB_URL == "http://example.com/repo/master.db"
+    assert cfg.DEFAULT_IMAGE_BASE_URL == "http://example.com/repo"


### PR DESCRIPTION
## Summary
- load default database/image URLs from `smart_price.config`
- configure `BASE_REPO_URL` via `.env` or `config.json`
- update tests for new configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b3f2a9e78832f9f906f9c313ad6d3