### PR TITLE
Save master Excel and DB

### DIFF
--- a/Price App/smart_price/config.py
+++ b/Price App/smart_price/config.py
@@ -11,6 +11,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Default locations matching the repository layout
 _DEFAULT_MASTER_DB_PATH = _REPO_ROOT / "Master data base" / "master.db"
+_DEFAULT_MASTER_EXCEL_PATH = _REPO_ROOT / "Master data base" / "master_dataset.xlsx"
 _DEFAULT_IMAGE_DIR = _REPO_ROOT / "images"
 _DEFAULT_SALES_APP_DIR = _REPO_ROOT / "Sales App" / "sales_app"
 _DEFAULT_PRICE_APP_DIR = _REPO_ROOT / "Price App" / "smart_price"
@@ -29,6 +30,7 @@ _DEFAULT_BASE_REPO_URL = (
 )
 
 # Public configuration variables (will be initialised by ``load_config``)
+MASTER_EXCEL_PATH: Path = _DEFAULT_MASTER_EXCEL_PATH
 MASTER_DB_PATH: Path = _DEFAULT_MASTER_DB_PATH
 IMAGE_DIR: Path = _DEFAULT_IMAGE_DIR
 SALES_APP_DIR: Path = _DEFAULT_SALES_APP_DIR
@@ -46,6 +48,7 @@ DEFAULT_DB_URL: str = f"{BASE_REPO_URL}/master.db"
 DEFAULT_IMAGE_BASE_URL: str = BASE_REPO_URL
 
 __all__ = [
+    "MASTER_EXCEL_PATH",
     "MASTER_DB_PATH",
     "IMAGE_DIR",
     "SALES_APP_DIR",
@@ -85,8 +88,9 @@ def load_config() -> None:
     def _get_str(name: str, default: str) -> str:
         return os.getenv(name, config.get(name, default))
 
-    global MASTER_DB_PATH, IMAGE_DIR, SALES_APP_DIR, PRICE_APP_DIR, DEBUG_DIR, OUTPUT_DIR, OUTPUT_EXCEL, OUTPUT_DB, OUTPUT_LOG, LOG_PATH, TESSERACT_CMD, TESSDATA_PREFIX, BASE_REPO_URL, DEFAULT_DB_URL, DEFAULT_IMAGE_BASE_URL
+    global MASTER_EXCEL_PATH, MASTER_DB_PATH, IMAGE_DIR, SALES_APP_DIR, PRICE_APP_DIR, DEBUG_DIR, OUTPUT_DIR, OUTPUT_EXCEL, OUTPUT_DB, OUTPUT_LOG, LOG_PATH, TESSERACT_CMD, TESSDATA_PREFIX, BASE_REPO_URL, DEFAULT_DB_URL, DEFAULT_IMAGE_BASE_URL
 
+    MASTER_EXCEL_PATH = _get("MASTER_EXCEL_PATH", _DEFAULT_MASTER_EXCEL_PATH)
     MASTER_DB_PATH = _get("MASTER_DB_PATH", _DEFAULT_MASTER_DB_PATH)
     IMAGE_DIR = _get("IMAGE_DIR", _DEFAULT_IMAGE_DIR)
     SALES_APP_DIR = _get("SALES_APP_DIR", _DEFAULT_SALES_APP_DIR)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ def test_defaults(monkeypatch):
     dotenv_stub.find_dotenv = lambda *_a, **_k: ''
     monkeypatch.setitem(sys.modules, 'dotenv', dotenv_stub)
     for name in (
+        "MASTER_EXCEL_PATH",
         "MASTER_DB_PATH",
         "IMAGE_DIR",
         "SALES_APP_DIR",
@@ -35,6 +36,7 @@ def test_defaults(monkeypatch):
         monkeypatch.delenv(name, raising=False)
     importlib.reload(cfg)
     root = Path(__file__).resolve().parent.parent
+    assert cfg.MASTER_EXCEL_PATH == root / "Master data base" / "master_dataset.xlsx"
     assert cfg.MASTER_DB_PATH == root / "Master data base" / "master.db"
     assert cfg.IMAGE_DIR == root / "images"
     assert cfg.SALES_APP_DIR == root / "Sales App" / "sales_app"
@@ -58,6 +60,7 @@ def test_env_and_config_overrides(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
     config_path.write_text('{"IMAGE_DIR": "imx"}')
     monkeypatch.setattr(cfg, "_REPO_ROOT", tmp_path)
+    monkeypatch.setenv("MASTER_EXCEL_PATH", str(tmp_path / "master.xlsx"))
     monkeypatch.setenv("MASTER_DB_PATH", str(tmp_path / "db.sqlite"))
     monkeypatch.setenv("DEBUG_DIR", str(tmp_path / "dbg"))
     monkeypatch.setenv("IMAGE_DIR", str(tmp_path / "img_env"))
@@ -71,6 +74,7 @@ def test_env_and_config_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("BASE_REPO_URL", "http://example.com/repo")
     importlib.reload(cfg)
     cfg.load_config()
+    assert cfg.MASTER_EXCEL_PATH == tmp_path / "master.xlsx"
     assert cfg.MASTER_DB_PATH == tmp_path / "db.sqlite"
     assert cfg.IMAGE_DIR == tmp_path / "img_env"
     assert cfg.SALES_APP_DIR == tmp_path / "sales"

--- a/tests/test_save_master_dataset.py
+++ b/tests/test_save_master_dataset.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+from pathlib import Path
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -43,7 +44,8 @@ def test_save_master_new(tmp_path, monkeypatch):
     import pandas as pd
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(streamlit_app.config, "MASTER_DB_PATH", tmp_path / "master_dataset.xlsx")
+    monkeypatch.setattr(streamlit_app.config, "MASTER_EXCEL_PATH", tmp_path / "master_dataset.xlsx")
+    monkeypatch.setattr(streamlit_app.config, "MASTER_DB_PATH", tmp_path / "master.db")
     df = pd.DataFrame({
         'Malzeme_Kodu': ['A1'],
         'Descriptions': ['Item'],
@@ -54,6 +56,8 @@ def test_save_master_new(tmp_path, monkeypatch):
 
     path = streamlit_app.save_master_dataset(df, mode="Yeni fiyat listesi")
     saved = pd.read_excel(path)
+    assert Path(path) == tmp_path / "master_dataset.xlsx"
+    assert (tmp_path / "master.db").exists()
     assert len(saved) == 1
     assert saved.iloc[0]['Malzeme_Kodu'] == 'A1'
 
@@ -64,7 +68,8 @@ def test_save_master_update(tmp_path, monkeypatch):
     import pandas as pd
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(streamlit_app.config, "MASTER_DB_PATH", tmp_path / "master_dataset.xlsx")
+    monkeypatch.setattr(streamlit_app.config, "MASTER_EXCEL_PATH", tmp_path / "master_dataset.xlsx")
+    monkeypatch.setattr(streamlit_app.config, "MASTER_DB_PATH", tmp_path / "master.db")
     master = pd.DataFrame({
         'Malzeme_Kodu': ['X1', 'Y1'],
         'Descriptions': ['Old', 'Keep'],
@@ -89,6 +94,8 @@ def test_save_master_update(tmp_path, monkeypatch):
 
     path = streamlit_app.save_master_dataset(new, mode="Güncelleme")
     result = pd.read_excel(path)
+    assert Path(path) == tmp_path / "master_dataset.xlsx"
+    assert (tmp_path / "master.db").exists()
     assert len(result) == 2
     assert 'old.xlsx' not in result[result['Descriptions'] == 'Old']['Kaynak_Dosya'].values
     assert not old_dir.exists()


### PR DESCRIPTION
## Summary
- set MASTER_EXCEL_PATH and MASTER_DB_PATH defaults in `config`
- export Excel and SQLite DB in `save_master_dataset`
- push saved files via `github_upload.upload_folder`
- update tests for new config paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b7cf40c2c832fb48046a863f43af7