### PR TITLE
Enhance dataset saving messages

### DIFF
--- a/Price App/smart_price/core/github_upload.py
+++ b/Price App/smart_price/core/github_upload.py
@@ -28,7 +28,7 @@ def _api_request(method: str, url: str, token: str, data: dict | None = None) ->
         raise
 
 
-def upload_folder(path: Path, *, remote_prefix: str = "LLM_Output_db") -> None:
+def upload_folder(path: Path, *, remote_prefix: str = "LLM_Output_db") -> bool:
     """Upload ``path`` to a GitHub repository.
 
     Parameters
@@ -45,8 +45,8 @@ def upload_folder(path: Path, *, remote_prefix: str = "LLM_Output_db") -> None:
     token = os.getenv("GITHUB_TOKEN")
     branch = os.getenv("GITHUB_BRANCH", "main")
     if not repo or not token:
-        logger.debug("GitHub repo or token not configured")
-        return
+        logger.info("GitHub repo or token not configured; skipping upload")
+        return False
 
     for file_path in path.rglob("*"):
         if not file_path.is_file():
@@ -67,4 +67,5 @@ def upload_folder(path: Path, *, remote_prefix: str = "LLM_Output_db") -> None:
             _api_request("PUT", url, token, data)
         except Exception:
             continue
+    return True
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ records are saved.
 From the interface you can upload Excel/PDF price lists and search the
 resulting master dataset. When you save the merged data it writes both
 `Master data base/master_dataset.xlsx` and `Master data base/master.db`
-relative to the directory from which you launch the app.
+relative to the directory from which you launch the app. The success
+message shows the full paths of these files and notes whether a GitHub
+upload was attempted.
 
 ### Logging
 
@@ -116,7 +118,8 @@ The log records extra details to help trace each step:
  - set `GITHUB_REPO` and `GITHUB_TOKEN` to automatically push each debug
    directory and the files under `Master data base/` (including
    `master_dataset.xlsx` and `master.db`) to the configured repository
-   under their respective folders (optionally specify `GITHUB_BRANCH`)
+   under their respective folders (optionally specify `GITHUB_BRANCH`).
+   If these variables are not set the upload is skipped gracefully.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- show full dataset locations and upload attempt in the Streamlit UI
- return DB path and upload flag from `save_master_dataset`
- report skipped GitHub upload when credentials are missing
- document new behaviour
- update unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b804e1ba0832fa339358a4bff7a5f