### PR TITLE
Fix run_sales_app NameError

### DIFF
--- a/run_sales_app.py
+++ b/run_sales_app.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import sys
 from streamlit.web import cli as stcli
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- import `sys` to resolve NameError in `run_sales_app.py`

## Testing
- `pytest -q`
- `python run_sales_app.py` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_b_683b9911bf34832f9218b2be38bcf2fd