### PR TITLE
Fix GitHub upload path

### DIFF
--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -651,5 +651,5 @@ def extract_from_pdf(
     cleanup()
     debug_dir = Path(os.getenv("SMART_PRICE_DEBUG_DIR", "LLM_Output_db")) / output_stem
     set_output_subdir(None)
-    upload_folder(debug_dir)
+    upload_folder(debug_dir, remote_prefix=f"LLM_Output_db/{debug_dir.name}")
     return result_df

--- a/Price App/smart_price/core/github_upload.py
+++ b/Price App/smart_price/core/github_upload.py
@@ -28,7 +28,7 @@ def _api_request(method: str, url: str, token: str, data: dict | None = None) ->
         raise
 
 
-def upload_folder(path: Path, *, remote_prefix: str = "LLM_Output_db") -> bool:
+def upload_folder(path: Path, *, remote_prefix: str | None = None) -> bool:
     """Upload ``path`` to a GitHub repository.
 
     Parameters
@@ -36,7 +36,8 @@ def upload_folder(path: Path, *, remote_prefix: str = "LLM_Output_db") -> bool:
     path : :class:`~pathlib.Path`
         Local directory to upload.
     remote_prefix : str, optional
-        Directory name created in the repository, by default ``"LLM_Output_db"``.
+        Folder prefix for uploaded files.  When ``None`` (default), files are
+        placed under ``"LLM_Output_db/<path.name>"`` in the repository.
 
     Requires ``GITHUB_REPO`` and ``GITHUB_TOKEN`` environment variables. Set
     ``GITHUB_BRANCH`` to push to a branch other than ``main``.
@@ -44,6 +45,8 @@ def upload_folder(path: Path, *, remote_prefix: str = "LLM_Output_db") -> bool:
     repo = os.getenv("GITHUB_REPO")
     token = os.getenv("GITHUB_TOKEN")
     branch = os.getenv("GITHUB_BRANCH", "main")
+    if remote_prefix is None:
+        remote_prefix = f"LLM_Output_db/{path.name}"
     if not repo or not token:
         logger.info("GitHub repo or token not configured; skipping upload")
         return False

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -395,6 +395,6 @@ def parse(
     logger.info("Finished %s with %d rows in %.2fs", pdf_path, len(df), total_dur)
     debug_dir = Path(os.getenv("SMART_PRICE_DEBUG_DIR", "LLM_Output_db")) / output_name
     set_output_subdir(None)
-    upload_folder(debug_dir)
+    upload_folder(debug_dir, remote_prefix=f"LLM_Output_db/{debug_dir.name}")
     return df
 


### PR DESCRIPTION
## Summary
- keep subdirectory when uploading debug output to GitHub
- add helper default to upload folder under `LLM_Output_db/<path.name>`
- upload pdf debug output with the correct remote prefix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b9ada79a8832f8507d97b7dbed32d