### PR TITLE
Switch to LLM-only PDF parsing

### DIFF
--- a/Price App/smart_price/core/extract_excel.py
+++ b/Price App/smart_price/core/extract_excel.py
@@ -173,7 +173,7 @@ def extract_from_excel(
             if df.empty:
                 continue
             code_col, short_col, desc_col, price_col, currency_col = find_columns_in_excel(df)
-            if (desc_col or code_col) and price_col and price_col in df.columns:
+            if code_col and price_col and price_col in df.columns and code_col in df.columns:
                 cols = []
                 if code_col and code_col in df.columns:
                     cols.append(code_col)
@@ -269,4 +269,12 @@ def extract_from_excel(
             src,
             dropped_preview,
         )
+    if (
+        tmp_df.empty
+        or "Malzeme_Kodu" not in tmp_df.columns
+        or "Fiyat" not in tmp_df.columns
+        or tmp_df["Malzeme_Kodu"].isna().all()
+        or tmp_df["Fiyat"].isna().all()
+    ):
+        return pd.DataFrame()
     return tmp_df

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -80,10 +80,9 @@ def extract_from_pdf_file(
     *,
     file_name: str | None = None,
     status_log: Optional[Callable[[str], None]] = None,
-    force_llm: bool = False,
 ) -> pd.DataFrame:
     """Wrapper around :func:`smart_price.core.extract_pdf.extract_from_pdf`."""
-    return extract_from_pdf(file, filename=file_name, log=status_log, force_llm=force_llm)
+    return extract_from_pdf(file, filename=file_name, log=status_log)
 
 
 def merge_files(
@@ -91,7 +90,6 @@ def merge_files(
     *,
     update_status: Optional[Callable[[str], None]] = None,
     update_progress: Optional[Callable[[float], None]] = None,
-    force_llm: bool = False,
 ):
     """Extract and merge uploaded files with optional progress callbacks."""
     extracted = []
@@ -113,7 +111,6 @@ def merge_files(
                     bytes_data,
                     file_name=up_file.name,
                     status_log=update_status,
-                    force_llm=force_llm,
                 )
         except Exception:
             df = pd.DataFrame()
@@ -297,7 +294,6 @@ def upload_page():
         type=["xlsx", "xls", "pdf"],
         accept_multiple_files=True,
     )
-    force_llm = st.checkbox("Force LLM (Vision)")
     if not files:
         return
 
@@ -308,7 +304,6 @@ def upload_page():
             files,
             update_status=status.write,
             update_progress=lambda v: progress_bar.progress(v),
-            force_llm=force_llm,
         )
         if df.empty:
             st.warning("Dosyalardan veri çıkarılamadı.")

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install .
 
 The tools attempt to locate the `tesseract` executable automatically using `shutil.which`. If `TESSDATA_PREFIX` is already defined it is respected, otherwise the location of the bundled language files is guessed from the executable path. When `tesseract` cannot be found a Windows default of `D:\Program Files\Tesseract-OCR` is used.
 
-PDF files are processed in two stages. First the parser attempts to read text directly using **pdfplumber**. If no products are found each page image is generated with **pdf2image** and sent directly to GPT‑4o Vision with a Turkish prompt. The model returns structured JSON describing the rows.
+PDF files are parsed entirely through GPT‑4o Vision. Each page image is generated with **pdf2image** and sent to the model with a Turkish prompt. The response contains structured JSON for the rows.
 
 ### LLM assistance
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -169,7 +169,7 @@ def test_extract_from_pdf_llm_no_data(monkeypatch):
     assert result.empty
 
 
-def test_extract_from_pdf_force_llm(monkeypatch):
+def test_extract_from_pdf_llm_only(monkeypatch):
     if not HAS_PANDAS:
         pytest.skip("pandas not installed")
 
@@ -210,7 +210,7 @@ def test_extract_from_pdf_force_llm(monkeypatch):
     import smart_price.core.extract_pdf as pdf_mod
     monkeypatch.setattr(pdf_mod.ocr_llm_fallback, "parse", fake_parse)
 
-    df = extract_from_pdf("dummy.pdf", force_llm=True)
+    df = extract_from_pdf("dummy.pdf")
 
     assert not df.empty
     assert called.get('path') == "dummy.pdf"
@@ -649,7 +649,7 @@ def test_merge_files_casts_to_string(monkeypatch):
     assert all(isinstance(v, str) for v in result["Malzeme_Kodu"])
 
 
-def test_merge_files_passes_force_llm(monkeypatch):
+def test_merge_files_pdf_called(monkeypatch):
     if not HAS_PANDAS:
         pytest.skip("pandas not installed")
     import pandas as pd
@@ -681,9 +681,9 @@ def test_merge_files_passes_force_llm(monkeypatch):
         def read(self):
             return b"data"
 
-    result = streamlit_app.merge_files([FakeUpload("f.pdf")], force_llm=True)
+    result = streamlit_app.merge_files([FakeUpload("f.pdf")])
 
-    assert received.get("force_llm") is True
+    assert received.get("file_name") == "f.pdf"
     assert not result.empty
 
 


### PR DESCRIPTION
## Summary
- rely solely on GPT-4o Vision for PDF extraction
- drop Force LLM option from Streamlit UI and tests
- require `Malzeme_Kodu` and `Fiyat` columns in Excel extraction
- update README to describe LLM-only PDF flow
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b9e3bdb44832fa64fd7d090db285c