### PR TITLE
Add database reset capability

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -19,7 +19,7 @@ from smart_price.core.extract_excel import extract_from_excel
 from smart_price.core.extract_pdf import extract_from_pdf, MIN_CODE_RATIO
 from smart_price import config
 from smart_price.core.logger import init_logging
-from smart_price.core.github_upload import upload_folder
+from smart_price.core.github_upload import upload_folder, delete_github_folder
 
 logger = logging.getLogger("smart_price")
 
@@ -282,6 +282,26 @@ def save_master_dataset(
     return excel_path, db_path, upload_result
 
 
+def reset_database() -> None:
+    """Remove local files and clear GitHub folders."""
+
+    if config.DEBUG_DIR.exists():
+        shutil.rmtree(config.DEBUG_DIR, ignore_errors=True)
+    if config.MASTER_DB_PATH.exists():
+        try:
+            config.MASTER_DB_PATH.unlink()
+        except Exception:
+            pass
+    if config.MASTER_EXCEL_PATH.exists():
+        try:
+            config.MASTER_EXCEL_PATH.unlink()
+        except Exception:
+            pass
+
+    delete_github_folder("LLM_Output_db")
+    delete_github_folder("Master data base")
+
+
 def upload_page():
     st.header("Fiyat Dosyalarını Yükle")
     st.radio(
@@ -352,9 +372,21 @@ def search_page():
         st.write(results)
 
 
+def reset_page():
+    st.header("Database Sıfırla")
+    if st.button("Sıfırla"):
+        try:
+            reset_database()
+        except Exception as exc:
+            st.error(f"Hata: {exc}")
+        else:
+            st.success("Veritabanı sıfırlandı")
+
+
 PAGES = {
     "Dosya Yükle": upload_page,
     "Veride Ara": search_page,
+    "Database Sıfırla": reset_page,
 }
 
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ The log records extra details to help trace each step:
    under their respective folders (optionally specify `GITHUB_BRANCH`).
    If these variables are not set the upload is skipped gracefully.
 
+### Resetting the dataset
+
+Use the **Database Sıfırla** page in the Streamlit interface to remove all
+local output and master files.  When GitHub credentials are configured the same
+folders (`LLM_Output_db` and `Master data base`) are cleared from the
+repository as well.
+
 ## Troubleshooting
 
 If the vision stage fails to produce any items, the log records the model name

--- a/tests/test_github_upload.py
+++ b/tests/test_github_upload.py
@@ -2,7 +2,11 @@ import os
 import types
 from pathlib import Path
 
-from smart_price.core.github_upload import _sanitize_repo_path, upload_folder
+from smart_price.core.github_upload import (
+    _sanitize_repo_path,
+    upload_folder,
+    delete_github_folder,
+)
 
 
 def test_sanitize_repo_path():
@@ -39,4 +43,33 @@ def test_upload_folder_encodes_url(tmp_path, monkeypatch):
 
     assert calls
     assert "%20" not in calls[0]
+
+
+def test_delete_github_folder(monkeypatch):
+    calls = []
+
+    def fake_api(method, url, token, data=None):
+        calls.append((method, url))
+        if method == "GET":
+            return [
+                {
+                    "type": "file",
+                    "path": "My_folder/file.txt",
+                    "sha": "1",
+                }
+            ]
+        return {}
+
+    monkeypatch.setattr(
+        "smart_price.core.github_upload._api_request", fake_api
+    )
+    monkeypatch.setenv("GITHUB_REPO", "owner/repo")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+
+    delete_github_folder("My folder")
+
+    assert calls[0][0] == "GET"
+    assert "My_folder" in calls[0][1]
+    assert "%20" not in calls[0][1]
+    assert calls[1][0] == "DELETE"
 


### PR DESCRIPTION
## Summary
- implement `delete_github_folder` helper for removing files via GitHub API
- add `reset_database` and `reset_page` in Streamlit app
- expose new "Database Sıfırla" page
- document database reset feature
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c4f795e9c832f936b8b9c2c161605