### PR TITLE
Handle invalid ellipsis outputs from LLM

### DIFF
--- a/Price App/smart_price/core/common_utils.py
+++ b/Price App/smart_price/core/common_utils.py
@@ -214,14 +214,21 @@ def safe_json_parse(text: str):
     if not text:
         return None
 
+    def _validate(obj):
+        return obj if isinstance(obj, (list, dict)) else None
+
     try:
-        return json.loads(text)
+        result = json.loads(text)
+        if _validate(result) is not None:
+            return result
     except Exception:
         pass
 
     text_sq = text.replace("'", '"')
     try:
-        return json.loads(text_sq)
+        result = json.loads(text_sq)
+        if _validate(result) is not None:
+            return result
     except Exception:
         pass
 
@@ -231,12 +238,15 @@ def safe_json_parse(text: str):
             lambda m: f'"{m.group(1)}":',
             text_sq,
         )
-        return json.loads(text_keys)
+        result = json.loads(text_keys)
+        if _validate(result) is not None:
+            return result
     except Exception:
         pass
 
     try:
-        return ast.literal_eval(text)
+        result = ast.literal_eval(text)
+        return _validate(result)
     except Exception:
         return None
 

--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -303,6 +303,8 @@ def extract_from_pdf(
 
         results = []
         for item in items:
+            if not isinstance(item, dict):
+                continue
             name = str(item.get("name") or item.get("product") or "").strip()
             price_raw = str(item.get("price", "")).strip()
             val = normalize_price(price_raw)

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -319,6 +319,8 @@ def parse(
 
         items = items if isinstance(items, list) else [items]
         for item in items:
+            if not isinstance(item, dict):
+                continue
             code = item.get("Malzeme_Kodu") or item.get("Malzeme Kodu")
             descr = item.get("Açıklama")
             price_raw = str(item.get("Fiyat", "")).strip()

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -1,0 +1,10 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from smart_price.core.common_utils import safe_json_parse
+
+
+def test_safe_json_parse_ellipsis():
+    assert safe_json_parse("...") is None
+


### PR DESCRIPTION
## Summary
- skip non-dict items returned by LLM helpers
- ensure `safe_json_parse` only returns lists or dicts
- test `safe_json_parse` with ellipsis input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c69a8a9bc832fa3ec2dac4f86df14