### PR TITLE
Add Streamlit theme configuration

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+primaryColor = "#002060"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F0F2F6"
+textColor = "#262730"
+font = "sans serif"

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -26,16 +26,15 @@ logger = logging.getLogger("smart_price")
 
 
 def big_alert(message: str, *, level: str = "info") -> None:
-    """Show a large coloured alert box in Streamlit."""
-    style = "font-size:20px;font-weight:bold;"
-    color_styles = {
-        "success": "background-color:#dff0d8;color:#3c763d;",
-        "error": "background-color:#f2dede;color:#a94442;",
-        "warning": "background-color:#fcf8e3;color:#8a6d3b;",
-        "info": "background-color:#d9edf7;color:#31708f;",
+    """Show an alert box styled using the active theme."""
+    mapping = {
+        "success": st.success,
+        "error": st.error,
+        "warning": st.warning,
+        "info": st.info,
     }
-    css = color_styles.get(level, color_styles["info"]) + style
-    st.markdown(f"<div style='{css}padding:0.5em;border-radius:0.5em;'>{message}</div>", unsafe_allow_html=True)
+    func: Callable[[str], None] = mapping.get(level, st.info)
+    func(f"**{message}**")
 
 
 def _img_to_base64(path: Path) -> str:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ Alternatively run the included launcher script from the repository root:
 python run_app.py
 ```
 
+The look and feel of the interface is defined in `.streamlit/config.toml`:
+
+```toml
+[theme]
+primaryColor = "#002060"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F0F2F6"
+textColor = "#262730"
+font = "sans serif"
+```
+
+Modify these values if you wish to adjust the colour scheme or font.
+
 The upload page now includes an **İşlem türü** radio button. Choose
 **Güncelleme** to overwrite existing data for the same brand, year and
 month. When this mode is used the matching rows are removed from the master


### PR DESCRIPTION
## Summary
- add a `.streamlit/config.toml` with theme colours
- simplify `big_alert` to use Streamlit's themed message boxes
- document the theme in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c863a4ad4832f88861c2d682f2231