### PR TITLE
Add themed styling to big_alert

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -57,12 +57,18 @@ def big_alert(message: str, *, level: str = "info", icon: str | None = None) -> 
     else:
         icon_b64 = icons.ICONS.get(level, icons.INFO_ICON_B64)
 
-    html = (
-        f"<p style='display:flex;align-items:center;gap:0.5em;'>"
-        f"<img src='data:image/png;base64,{icon_b64}' "
-        f"style='width:1.3em;height:1.3em;'/>"
-        f"<strong>{message}</strong></p>"
-    )
+    theme = st.get_option("theme") or {}
+    text_colour = theme.get("textColor", "#262730")
+    bg_colour = theme.get("secondaryBackgroundColor", "#F0F2F6")
+
+    html = f"""
+        <div style='display:flex;align-items:center;gap:0.5em;padding:0.75em;"
+        f"background:{bg_colour};color:{text_colour};border-radius:0.5em;"
+        f"font-size:1.1rem;font-weight:600;'>
+            <img src='data:image/png;base64,{icon_b64}' style='width:1.5em;height:1.5em;' />
+            <span>{message}</span>
+        </div>
+    """
     func(html, unsafe_allow_html=True)
 
 

--- a/tests/test_big_alert.py
+++ b/tests/test_big_alert.py
@@ -19,6 +19,8 @@ def _setup_streamlit(monkeypatch):
     for lvl in ("success", "error", "warning", "info"):
         setattr(st_stub, lvl, make(lvl))
 
+    st_stub.get_option = lambda name: {}
+
     monkeypatch.setitem(sys.modules, "streamlit", st_stub)
 
     # Minimal stubs for optional dependencies
@@ -58,4 +60,6 @@ def test_big_alert_default_icon(monkeypatch, tmp_path):
     assert "success" in captured
     msg, allow = captured["success"]
     assert icons.SUCCESS_ICON_B64 in msg
+    assert "<div" in msg
+    assert "Hello" in msg
     assert allow is True


### PR DESCRIPTION
## Summary
- style `big_alert` using Streamlit theme colours
- expand icons and message styling
- update tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c92a8915c832fbe4cf0b0d63d1f0d