### PR TITLE
Use embedded icons for big_alert

### DIFF
--- a/Price App/smart_price/icons.py
+++ b/Price App/smart_price/icons.py
@@ -1,4 +1,17 @@
-"""Base64 encoded icons for use in the Streamlit UI."""
+"""Base64 encoded icons for use in the Streamlit UI.
+
+The constants defined here are tiny 1\u00d71 pixel PNG images encoded as
+base64 strings.  They are used by :func:`smart_price.streamlit_app.big_alert`
+as fallbacks when no custom icon path is supplied.
+"""
+
+__all__ = [
+    "SUCCESS_ICON_B64",
+    "ERROR_ICON_B64",
+    "WARNING_ICON_B64",
+    "INFO_ICON_B64",
+    "ICONS",
+]
 
 SUCCESS_ICON_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNg+M8AAAICAQB7CYF4AAAAAElFTkSuQmCC"
 ERROR_ICON_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"


### PR DESCRIPTION
## Summary
- document bundled Streamlit icons

## Testing
- `pytest tests/test_big_alert.py::test_big_alert_default_icon -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683c927f04a0832fb84a5b2d6c0d4cee