### PR TITLE
Fix big_alert compatibility with latest Streamlit

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -42,13 +42,9 @@ def big_alert(message: str, *, level: str = "info", icon: str | None = None) -> 
         encoded icon from :mod:`smart_price.icons` is used.
     """
 
-    mapping = {
-        "success": st.success,
-        "error": st.error,
-        "warning": st.warning,
-        "info": st.info,
-    }
-    func: Callable[[str], None] = mapping.get(level, st.info)
+    # ``st.success`` and friends used to accept ``unsafe_allow_html`` but this
+    # parameter was removed in newer Streamlit versions.  To maintain the custom
+    # HTML formatting we always use ``st.markdown``.
 
     if icon:
         with open(icon, "rb") as img_file:
@@ -71,7 +67,7 @@ def big_alert(message: str, *, level: str = "info", icon: str | None = None) -> 
             <span>{message}</span>
         </div>
     """
-    func(html, unsafe_allow_html=True)
+    st.markdown(html, unsafe_allow_html=True)
 
 
 def _configure_tesseract() -> None:

--- a/tests/test_big_alert.py
+++ b/tests/test_big_alert.py
@@ -11,13 +11,13 @@ def _setup_streamlit(monkeypatch):
     captured = {}
     st_stub = types.ModuleType("streamlit")
 
-    def make(level):
+    def make(name):
         def func(msg, *, unsafe_allow_html=False):
-            captured[level] = (msg, unsafe_allow_html)
+            captured[name] = (msg, unsafe_allow_html)
         return func
 
-    for lvl in ("success", "error", "warning", "info"):
-        setattr(st_stub, lvl, make(lvl))
+    # Capture markdown calls used by ``big_alert``
+    st_stub.markdown = make("markdown")
 
     st_stub.get_option = lambda name: {}
 
@@ -57,8 +57,8 @@ def test_big_alert_default_icon(monkeypatch, tmp_path):
     from smart_price.streamlit_app import big_alert
 
     big_alert("Hello", level="success")
-    assert "success" in captured
-    msg, allow = captured["success"]
+    assert "markdown" in captured
+    msg, allow = captured["markdown"]
     assert icons.SUCCESS_ICON_B64 in msg
     assert "<div" in msg
     assert "Hello" in msg


### PR DESCRIPTION
## Summary
- handle custom alert rendering with st.markdown
- adjust big_alert tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683caf110a00832f8c0744a005dd54f4