### PR TITLE
Fix PyInstaller build for streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The script bundles everything inside the `data` directory so that any price
 lists placed there (for example an initial `master_dataset.xlsx`) are available
 once the executable is launched. The resulting binary will appear in the
 `dist` folder.
+The batch file collects all Streamlit resources so the executable launches
+without a `PackageNotFoundError` for the `streamlit` distribution.
 
 ### Price normalization
 

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -5,6 +5,6 @@ REM Requires pyinstaller to be installed: pip install pyinstaller
 set SCRIPT=streamlit_app.py
 set DATAFOLDER=data
 
-pyinstaller --noconfirm --onefile --add-data "%DATAFOLDER%;%DATAFOLDER%" --hidden-import "streamlit.web.cli" %SCRIPT%
+pyinstaller --noconfirm --onefile --add-data "%DATAFOLDER%;%DATAFOLDER%" --hidden-import "streamlit.web.cli" --collect-all streamlit %SCRIPT%
 
 ECHO Build complete. Look in the dist folder for the EXE.


### PR DESCRIPTION
## Summary
- ensure `pyinstaller` collects Streamlit resources when building the Windows exe
- mention this in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ccb2b34b4832f8b955a54b79e97aa