### PR TITLE
Fix build script path

### DIFF
--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -2,9 +2,9 @@
 REM Build standalone Windows executable for Streamlit app
 REM Requires pyinstaller to be installed: pip install pyinstaller
 
-set SCRIPT=streamlit_app.py
+set SCRIPT=Price App\smart_price\streamlit_app.py
 set DATAFOLDER=data
 
-pyinstaller --noconfirm --onefile --add-data "%DATAFOLDER%;%DATAFOLDER%" --hidden-import "streamlit.web.cli" --collect-all streamlit %SCRIPT%
+pyinstaller --noconfirm --onefile --add-data "%DATAFOLDER%;%DATAFOLDER%" --hidden-import "streamlit.web.cli" --collect-all streamlit "%SCRIPT%"
 
 ECHO Build complete. Look in the dist folder for the EXE.


### PR DESCRIPTION
## Summary
- fix path to Streamlit app in `build_windows_exe.bat`
- quote path when calling PyInstaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ccc28bba4832f8146d74fd9cad413