### PR TITLE
Fix import for img_to_base64

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional
 import base64
 
 from smart_price import icons
+from smart_price.ui_utils import img_to_base64
 
 from smart_price.core.extract_excel import extract_from_excel
 from smart_price.core.extract_pdf import extract_from_pdf, MIN_CODE_RATIO


### PR DESCRIPTION
## Summary
- add missing img_to_base64 import in streamlit_app.py

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683cd043df68832f8cc6316bef1caac4