### PR TITLE
Fix packaging by bundling logo folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ build_windows_exe.bat
 
 The script bundles everything inside the `data` directory so that any price
 lists placed there (for example an initial `master_dataset.xlsx`) are available
-once the executable is launched. The resulting binary will appear in the
-`dist` folder.
+once the executable is launched.  It also adds the `logo` folder to ensure
+the images used by the interface are packaged.  The resulting binary will
+appear in the `dist` folder.
 The batch file collects all Streamlit resources so the executable launches
 without a `PackageNotFoundError` for the `streamlit` distribution.
 

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -4,7 +4,8 @@ REM Requires pyinstaller to be installed: pip install pyinstaller
 
 set SCRIPT=Price App\smart_price\streamlit_app.py
 set DATAFOLDER=data
+set LOGOFOLDER=logo
 
-pyinstaller --noconfirm --onefile --add-data "%DATAFOLDER%;%DATAFOLDER%" --hidden-import "streamlit.web.cli" --collect-all streamlit "%SCRIPT%"
+pyinstaller --noconfirm --onefile --add-data "%DATAFOLDER%;%DATAFOLDER%" --add-data "%LOGOFOLDER%;logo" --hidden-import "streamlit.web.cli" --collect-all streamlit "%SCRIPT%"
 
 ECHO Build complete. Look in the dist folder for the EXE.


### PR DESCRIPTION
## Summary
- include `logo` folder when building the Windows executable
- mention bundled images in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cd32b8a8c832f8ed01a5337de4d59