### PR TITLE
Fix PyInstaller script to use launcher

### DIFF
--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -2,7 +2,8 @@
 REM Build standalone Windows executable for Streamlit app
 REM Requires pyinstaller to be installed: pip install pyinstaller
 
-set SCRIPT=Price App\smart_price\streamlit_app.py
+REM Entry script that launches Streamlit using stcli
+set SCRIPT=run_app.py
 set DATAFOLDER=data
 set LOGOFOLDER=logo
 


### PR DESCRIPTION
## Summary
- build executable using `run_app.py` so Streamlit runs with the correct context

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683cd92ca054832fb24084cc71f62f9f