### PR TITLE
Fix Streamlit executable path

### DIFF
--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -6,7 +6,12 @@ REM Entry script that launches Streamlit using stcli
 set SCRIPT=run_app.py
 set DATAFOLDER=data
 set LOGOFOLDER=logo
+set PRICEAPP=Price App
 
-pyinstaller --noconfirm --onefile --add-data "%DATAFOLDER%;%DATAFOLDER%" --add-data "%LOGOFOLDER%;logo" --hidden-import "streamlit.web.cli" --collect-all streamlit "%SCRIPT%"
+pyinstaller --noconfirm --onefile ^
+    --add-data "%DATAFOLDER%;%DATAFOLDER%" ^
+    --add-data "%LOGOFOLDER%;logo" ^
+    --add-data "%PRICEAPP%;Price App" ^
+    --hidden-import "streamlit.web.cli" --collect-all streamlit "%SCRIPT%"
 
 ECHO Build complete. Look in the dist folder for the EXE.

--- a/run_app.py
+++ b/run_app.py
@@ -13,7 +13,12 @@ from streamlit.web import cli as stcli
 load_dotenv(dotenv_path=find_dotenv())
 
 if __name__ == "__main__":
-    pkg_root = pathlib.Path(__file__).parent
+    # When bundled by PyInstaller the application files are extracted to a
+    # temporary directory available via ``sys._MEIPASS``.  Using this location
+    # ensures the Streamlit script can be found regardless of whether we run
+    # from source or from the generated executable.
+    base_path = pathlib.Path(getattr(sys, "_MEIPASS", pathlib.Path(__file__).parent))
+    pkg_root = base_path
     sys.path.insert(0, str(pkg_root / "Price App"))
     sys.argv = [
         "streamlit",


### PR DESCRIPTION
## Summary
- use `sys._MEIPASS` when available so the bundled executable can locate the Streamlit script
- include `Price App` directory when building the Windows executable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683cde6e67a0832f8b4d2e0018f278d9