### PR TITLE
Use remote logos

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -19,6 +19,13 @@ import base64
 from smart_price import icons
 from smart_price.ui_utils import img_to_base64
 
+left_logo_url = (
+    "https://raw.githubusercontent.com/muratturan19/Smart_Price/main/logo/dp_Seffaf_logo.PNG"
+)
+right_logo_url = (
+    "https://raw.githubusercontent.com/muratturan19/Smart_Price/main/logo/sadece_dp_seffaf.PNG"
+)
+
 from smart_price.core.extract_excel import extract_from_excel
 from smart_price.core.extract_pdf import extract_from_pdf, MIN_CODE_RATIO
 from smart_price import config
@@ -501,8 +508,8 @@ def main():
     _configure_tesseract()
     st.set_page_config(layout="wide")
 
-    left_logo_b64 = img_to_base64(Path(resource_path("logo/dp_logo.png")))
-    right_logo_b64 = img_to_base64(Path(resource_path("logo/delta_logo_150p.png")))
+    left_logo_b64 = img_to_base64(left_logo_url)
+    right_logo_b64 = img_to_base64(right_logo_url)
 
     header_html = f"""
         <header class='app-header'>

--- a/Price App/smart_price/ui_utils.py
+++ b/Price App/smart_price/ui_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import base64
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:  # pragma: no cover - hint for type checkers
     import streamlit as st
@@ -11,14 +11,23 @@ if TYPE_CHECKING:  # pragma: no cover - hint for type checkers
 from . import config
 
 
-def img_to_base64(path: Path) -> str:
-    """Return base64 string for the image at ``path``."""
-    with open(path, "rb") as img_file:
-        return base64.b64encode(img_file.read()).decode("utf-8")
+def img_to_base64(path: Union[Path, str]) -> str:
+    """Return base64 string for the image at ``path`` or URL."""
+    if isinstance(path, (str, Path)) and str(path).startswith("http"):
+        import requests
+
+        resp = requests.get(str(path))
+        resp.raise_for_status()
+        data = resp.content
+    else:
+        with open(Path(path), "rb") as img_file:
+            data = img_file.read()
+
+    return base64.b64encode(data).decode("utf-8")
 
 
 def logo_overlay(
-    path: Path,
+    path: Union[Path, str],
     *,
     top: str | None = None,
     right: str | None = None,

--- a/Sales App/sales_app/streamlit_app.py
+++ b/Sales App/sales_app/streamlit_app.py
@@ -9,9 +9,15 @@ import pandas as pd
 import requests
 import streamlit as st
 from pathlib import Path
-import base64
 import sys
 from smart_price.ui_utils import img_to_base64, logo_overlay
+
+left_logo_url = (
+    "https://raw.githubusercontent.com/muratturan19/Smart_Price/main/logo/dp_Seffaf_logo.PNG"
+)
+right_logo_url = (
+    "https://raw.githubusercontent.com/muratturan19/Smart_Price/main/logo/sadece_dp_seffaf.PNG"
+)
 
 
 def resource_path(relative: str) -> str:
@@ -117,8 +123,7 @@ def search_page(df: pd.DataFrame) -> None:
 def main() -> None:
     st.set_page_config(layout="wide")
 
-    sidebar_logo = Path(resource_path("logo/dp_logo.png"))
-    sidebar_logo_b64 = img_to_base64(sidebar_logo)
+    sidebar_logo_b64 = img_to_base64(left_logo_url)
     st.sidebar.markdown(
         f"<img src='data:image/png;base64,{sidebar_logo_b64}' "
         "style='display:block;margin:20px auto 10px;"
@@ -126,8 +131,7 @@ def main() -> None:
         unsafe_allow_html=True,
     )
 
-    top_logo = Path(resource_path("logo/delta_logo_150p.png"))
-    logo_overlay(top_logo, tooltip="Delta Proje")
+    logo_overlay(right_logo_url, tooltip="Delta Proje")
 
     st.sidebar.title("Smart Price Sales")
     df = get_master_dataset()


### PR DESCRIPTION
## Summary
- allow `img_to_base64` to fetch from URLs
- load header and sidebar logos directly from GitHub raw links in both apps
- update `logo_overlay` helper to accept URL sources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d61be25e8832fa7d11d49b64646e8