### PR TITLE
Ensure Streamlit EXE uses correct port

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ build_windows_exe.bat
 The script bundles everything inside the `data` directory so that any price
 lists placed there (for example an initial `master_dataset.xlsx`) are available
 once the executable is launched.  It also adds the `logo` folder to ensure
-the images used by the interface are packaged.  The resulting binary will
-appear in the `dist` folder.
+the images used by the interface are packaged together with the `.streamlit`
+configuration folder.  The resulting binary will appear in the `dist` folder.
 The batch file collects all Streamlit resources so the executable launches
 without a `PackageNotFoundError` for the `streamlit` distribution.
+The launcher script sets `STREAMLIT_SERVER_PORT=8501` and
+`STREAMLIT_SERVER_HEADLESS=true` to ensure the app listens on the usual port
+when run from the generated EXE.
 
 ### Price normalization
 

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -7,11 +7,13 @@ set SCRIPT=run_app.py
 set DATAFOLDER=data
 set LOGOFOLDER=logo
 set PRICEAPP=Price App
+set STREAMLITCFG=.streamlit
 
 pyinstaller --noconfirm --onefile ^
     --add-data "%DATAFOLDER%;%DATAFOLDER%" ^
     --add-data "%LOGOFOLDER%;logo" ^
     --add-data "%PRICEAPP%;Price App" ^
+    --add-data "%STREAMLITCFG%;.streamlit" ^
     --hidden-import "streamlit.web.cli" --collect-all streamlit "%SCRIPT%"
 
 ECHO Build complete. Look in the dist folder for the EXE.

--- a/run_app.py
+++ b/run_app.py
@@ -1,6 +1,10 @@
 import os
 import sys
 import pathlib
+
+# Ensure a consistent Streamlit configuration when packaged
+os.environ["STREAMLIT_SERVER_PORT"] = "8501"
+os.environ["STREAMLIT_SERVER_HEADLESS"] = "true"
 try:
     from dotenv import load_dotenv, find_dotenv
 except ImportError:  # pragma: no cover - support missing find_dotenv


### PR DESCRIPTION
## Summary
- make `run_app.py` force Streamlit to use port 8501 in headless mode
- bundle `.streamlit` configuration when building the Windows EXE
- document the behaviour in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683d854dfda8832f8e94ef56f3a707d3