### PR TITLE
Add poppler config support

### DIFF
--- a/Price App/smart_price/config.py
+++ b/Price App/smart_price/config.py
@@ -30,7 +30,7 @@ _DEFAULT_OUTPUT_LOG = _DEFAULT_OUTPUT_DIR / "source_log.csv"
 _DEFAULT_LOG_PATH = _REPO_ROOT / "smart_price.log"
 _DEFAULT_TESSERACT_CMD = Path(r"D:\\Program Files\\Tesseract-OCR\\tesseract.exe")
 _DEFAULT_TESSDATA_PREFIX = Path(r"D:\\Program Files\\Tesseract-OCR\\tessdata")
-_DEFAULT_POPPLER_PATH = _REPO_ROOT / "poppler" / "bin"
+_DEFAULT_POPPLER_PATH = Path(__file__).resolve().parents[2] / "poppler" / "bin"
 
 # Default remote repository for the public demo data
 _DEFAULT_BASE_REPO_URL = (

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -89,14 +89,16 @@ def parse(
         return pd.DataFrame()
 
     try:
-        kwargs = {"dpi": 300, "poppler_path": str(config.POPPLER_PATH)}
+        kwargs = {"dpi": 300}
         first, last = _range_bounds(page_range)
         if first is not None:
             kwargs["first_page"] = first
         if last is not None:
             kwargs["last_page"] = last
         start_convert = time.time()
-        images = convert_from_path(pdf_path, **kwargs)
+        images = convert_from_path(
+            pdf_path, poppler_path=str(config.POPPLER_PATH), **kwargs
+        )
         logger.info(
             "pdf2image.convert_from_path took %.2fs for %d pages",
             time.time() - start_convert,

--- a/Price App/smart_price/price_parser.py
+++ b/Price App/smart_price/price_parser.py
@@ -20,6 +20,7 @@ from smart_price.core.logger import init_logging
 logger = logging.getLogger("smart_price")
 
 def _configure_tesseract() -> None:
+    _configure_poppler()
     """Configure pytesseract paths and log available languages.
 
     ``pytesseract`` relies on ``tesseract`` being available on the system
@@ -51,6 +52,16 @@ def _configure_tesseract() -> None:
             )
     except Exception as exc:  # pragma: no cover - unexpected errors
         logger.error("Tesseract language query failed: %s", exc)
+
+def _configure_poppler() -> None:
+    """Ensure bundled Poppler binaries are on ``PATH``."""
+    if shutil.which("pdftoppm"):
+        return
+    os.environ["PATH"] = os.pathsep.join([
+        str(config.POPPLER_PATH),
+        os.environ.get("PATH", "")
+    ])
+
 
 
 
@@ -95,6 +106,7 @@ def main() -> None:
             print(f"Log file not found: {log_file}")
         return
     _configure_tesseract()
+    _configure_poppler()
     os.makedirs(os.path.dirname(args.output), exist_ok=True)
     os.makedirs(os.path.dirname(args.db), exist_ok=True)
     os.makedirs(os.path.dirname(args.log), exist_ok=True)

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -111,6 +111,15 @@ def _configure_tesseract() -> None:
         logger.error("Tesseract language query failed: %s", exc)
 
 
+def _configure_poppler() -> None:
+    """Ensure bundled Poppler binaries are on ``PATH``."""
+    if shutil.which("pdftoppm"):
+        return
+    os.environ["PATH"] = os.pathsep.join(
+        [str(config.POPPLER_PATH), os.environ.get("PATH", "")]
+    )
+
+
 def resource_path(relative: str) -> str:
     """Return absolute path to resource, works for PyInstaller bundles."""
     base_path = getattr(sys, "_MEIPASS", Path(__file__).parent)
@@ -506,6 +515,7 @@ PAGES = {
 def main():
     init_logging(config.LOG_PATH)
     _configure_tesseract()
+    _configure_poppler()
     st.set_page_config(layout="wide")
 
     left_logo_b64 = img_to_base64(left_logo_url)
@@ -560,6 +570,7 @@ def cli() -> None:
     """Entry point to launch the Streamlit application."""
     init_logging(config.LOG_PATH)
     _configure_tesseract()
+    _configure_poppler()
     from streamlit.web import cli as stcli
 
     sys.argv = ["streamlit", "run", __file__]


### PR DESCRIPTION
## Summary
- add POPPLER_PATH default and expose in config
- ensure poppler executables are found when packaged
- pass poppler path explicitly to pdf2image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683da59da818832f981fb849ebf398d4