### PR TITLE
Improve Windows build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ lists placed there (for example an initial `master_dataset.xlsx`) are available
 once the executable is launched.  It also adds the `logo` folder to ensure
 the images used by the interface are packaged together with the `.streamlit`
 configuration folder.  The resulting binary will appear in the `dist` folder.
-Poppler binaries (`pdftoppm.exe` and `pdftocairo.exe`) must be located under
-`poppler/bin` so the script can include them in the package.
-The batch file collects all Streamlit resources so the executable launches
-without a `PackageNotFoundError` for the `streamlit` distribution.
-The launcher script sets `STREAMLIT_SERVER_PORT=8501` and
-`STREAMLIT_SERVER_HEADLESS=true` to ensure the app listens on the usual port
-when run from the generated EXE.
+Both Poppler and Tesseract binaries are bundled from the `poppler/bin` folder
+so no separate installation is required.  If you store these tools elsewhere
+edit `POPLPLERDIR` (and set `TESSERACT_CMD` if needed) in
+`build_windows_exe.bat` to point to the correct paths.  The batch file
+collects all Streamlit resources so the executable launches without a
+`PackageNotFoundError` for the `streamlit` distribution. The launcher script
+sets `STREAMLIT_SERVER_PORT=8501` and `STREAMLIT_SERVER_HEADLESS=true` to
+ensure the app listens on the usual port when run from the generated EXE.
 
 ### Price normalization
 


### PR DESCRIPTION
## Summary
- clarify that Poppler and Tesseract binaries are bundled when building the Windows executable
- mention the `poppler` folder and how to update paths in `build_windows_exe.bat`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683da790ea6c832f9d1a640857259fa5