### PR TITLE
Rename Descriptions field to Açıklama

### DIFF
--- a/Price App/smart_price/core/extract_excel.py
+++ b/Price App/smart_price/core/extract_excel.py
@@ -272,10 +272,10 @@ def extract_from_excel(
         + "|"
         + (combined.groupby("Sayfa").cumcount() + 1).astype(str)
     )
-    combined.rename(columns={"Malzeme_Adi": "Descriptions"}, inplace=True)
+    combined.rename(columns={"Malzeme_Adi": "Açıklama"}, inplace=True)
     cols = [
         "Malzeme_Kodu",
-        "Descriptions",
+        "Açıklama",
         "Kisa_Kod",
         "Fiyat",
         "Para_Birimi",
@@ -288,9 +288,9 @@ def extract_from_excel(
     ]
     tmp_df = combined[cols].copy()
     before_df = tmp_df.copy()
-    drop_mask = tmp_df[["Descriptions", "Fiyat"]].isna().any(axis=1)
+    drop_mask = tmp_df[["Açıklama", "Fiyat"]].isna().any(axis=1)
     dropped_preview = tmp_df[drop_mask].head().to_dict(orient="records")
-    tmp_df.dropna(subset=["Descriptions", "Fiyat"], inplace=True)
+    tmp_df.dropna(subset=["Açıklama", "Fiyat"], inplace=True)
     logger.debug(
         "[%s] Filter sonrası: %d satır (drop edilen: %d satır)",
         src,
@@ -298,7 +298,7 @@ def extract_from_excel(
         len(before_df) - len(tmp_df),
     )
     if len(before_df) != len(tmp_df):
-        logger.debug("[%s] Drop nedeni: subset=['Descriptions', 'Fiyat']", src)
+        logger.debug("[%s] Drop nedeni: subset=['Açıklama', 'Fiyat']", src)
         logger.debug(
             "[%s] Drop edilen ilk 5 satır: %s",
             src,

--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -319,7 +319,7 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
     if brand_from_file:
         result["Marka"] = brand_from_file
     else:
-        result["Marka"] = result["Descriptions"].apply(detect_brand)
+        result["Marka"] = result["Açıklama"].apply(detect_brand)
     result["Kategori"] = None
     if "Kisa_Kod" not in result.columns:
         result["Kisa_Kod"] = None
@@ -340,7 +340,7 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
     )
     cols = [
         "Malzeme_Kodu",
-        "Descriptions",
+        "Açıklama",
         "Kisa_Kod",
         "Fiyat",
         "Para_Birimi",

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -279,7 +279,7 @@ def parse(
             page_rows.append(
                 {
                     "Malzeme_Kodu": code,
-                    "Descriptions": descr,
+                    "Açıklama": descr,
                     "Ana_Baslik": main_title,
                     "Alt_Baslik": sub_title,
                     "Fiyat": normalize_price(price_raw),

--- a/Price App/smart_price/parsers.py
+++ b/Price App/smart_price/parsers.py
@@ -77,10 +77,10 @@ def parse_df(df: pd.DataFrame) -> pd.DataFrame:
     if "Malzeme_Kodu" not in result.columns:
         result["Malzeme_Kodu"] = None
     result["Record_Code"] = None
-    result.rename(columns={"Malzeme_Adi": "Descriptions"}, inplace=True)
+    result.rename(columns={"Malzeme_Adi": "Açıklama"}, inplace=True)
     cols_out = [
         "Malzeme_Kodu",
-        "Descriptions",
+        "Açıklama",
         "Kisa_Kod",
         "Fiyat",
         "Para_Birimi",
@@ -88,5 +88,5 @@ def parse_df(df: pd.DataFrame) -> pd.DataFrame:
         "Kaynak_Dosya",
         "Record_Code",
     ]
-    return result[cols_out].dropna(subset=["Descriptions", "Fiyat"])
+    return result[cols_out].dropna(subset=["Açıklama", "Fiyat"])
 

--- a/Price App/smart_price/price_parser.py
+++ b/Price App/smart_price/price_parser.py
@@ -138,7 +138,7 @@ def main() -> None:
         return
     master = pd.concat(all_extracted, ignore_index=True)
     master.drop_duplicates(subset=["Malzeme_Kodu", "Fiyat"], keep="last", inplace=True)
-    master.sort_values(by="Descriptions", inplace=True)
+    master.sort_values(by="Açıklama", inplace=True)
     master.to_excel(args.output, index=False)
     logger.info("Saved %d records to %s", len(master), args.output)
 
@@ -166,7 +166,7 @@ def main() -> None:
         master.rename(
             columns={
                 "Malzeme_Kodu": "material_code",
-                "Descriptions": "description",
+                "Açıklama": "description",
                 "Fiyat": "price",
                 "Birim": "unit",
                 "Kutu_Adedi": "box_count",

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -192,7 +192,7 @@ def merge_files(
             update_progress(idx / total)
 
     if not extracted:
-        return pd.DataFrame(columns=["Descriptions", "Fiyat"])
+        return pd.DataFrame(columns=["Açıklama", "Fiyat"])
 
     if update_progress:
         update_progress(1.0)
@@ -212,8 +212,8 @@ def merge_files(
     if before_len != len(master):
         logger.debug("[merge] Drop nedeni: subset=['Malzeme_Kodu', 'Fiyat']")
         logger.debug("[merge] Drop edilen ilk 5 satır: %s", dropped_preview)
-    master["Descriptions"] = master["Descriptions"].astype(str).str.strip().str.upper()
-    master.sort_values(by="Descriptions", inplace=True)
+    master["Açıklama"] = master["Açıklama"].astype(str).str.strip().str.upper()
+    master.sort_values(by="Açıklama", inplace=True)
     if "Kisa_Kod" in master.columns:
         master["Kisa_Kod"] = master["Kisa_Kod"].astype(str)
     if "Malzeme_Kodu" in master.columns:
@@ -299,7 +299,7 @@ def save_master_dataset(
         db_df.rename(
             columns={
                 "Malzeme_Kodu": "material_code",
-                "Descriptions": "description",
+                "Açıklama": "description",
                 "Fiyat": "price",
                 "Birim": "unit",
                 "Kutu_Adedi": "box_count",
@@ -474,7 +474,7 @@ def search_page():
     query = st.text_input("Malzeme kodu veya adı")
     if query:
         results = master_df[
-            master_df["Descriptions"].str.contains(query, case=False, na=False)
+            master_df["Açıklama"].str.contains(query, case=False, na=False)
         ]
         if not results.empty:
             try:

--- a/Sales App/sales_app/streamlit_app.py
+++ b/Sales App/sales_app/streamlit_app.py
@@ -70,7 +70,7 @@ def search_page(df: pd.DataFrame) -> None:
 
     filtered = df
     if query:
-        filtered = filtered[filtered["Descriptions"].str.contains(query, case=False, na=False) |
+        filtered = filtered[filtered["Açıklama"].str.contains(query, case=False, na=False) |
                               filtered["Malzeme_Kodu"].str.contains(query, case=False, na=False)]
     if brand:
         filtered = filtered[filtered["Marka"] == brand]
@@ -83,7 +83,7 @@ def search_page(df: pd.DataFrame) -> None:
     if not filtered.empty:
         def _fmt(idx: int) -> str:
             row = filtered.loc[idx]
-            return f"{row['Descriptions']} ({row['Malzeme_Kodu']})"
+            return f"{row['Açıklama']} ({row['Malzeme_Kodu']})"
 
         selected = st.selectbox(
             "Ürün seç",

--- a/tests/test_page_summary.py
+++ b/tests/test_page_summary.py
@@ -39,7 +39,7 @@ def test_extract_from_pdf_summary(monkeypatch):
         import pandas as pd
         df = pd.DataFrame({
             "Malzeme_Kodu": ["A"],
-            "Descriptions": ["Item"],
+            "Açıklama": ["Item"],
             "Fiyat": [1.0],
             "Sayfa": [1],
         })

--- a/tests/test_parser_df.py
+++ b/tests/test_parser_df.py
@@ -21,6 +21,6 @@ def test_parse_df_item_name():
     df = pd.DataFrame({"Item Name": ["A1"], "Price": ["10"]})
     result = parse_df(df)
     assert result.iloc[0]["Malzeme_Kodu"] == "A1"
-    assert result.iloc[0]["Descriptions"] == "A1"
+    assert result.iloc[0]["Açıklama"] == "A1"
     assert result.iloc[0]["Fiyat"] == 10.0
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -67,10 +67,10 @@ def test_extract_from_excel_basic(tmp_path):
     assert len(result) == 2
     assert result.iloc[0]["Fiyat"] == 1000.50
     assert result.iloc[1]["Fiyat"] == 2500.75
-    assert result["Descriptions"].tolist() == ["Elma", "Armut"]
+    assert result["Açıklama"].tolist() == ["Elma", "Armut"]
     expected_cols = [
         "Malzeme_Kodu",
-        "Descriptions",
+        "Açıklama",
         "Kisa_Kod",
         "Fiyat",
         "Para_Birimi",
@@ -120,7 +120,7 @@ def test_extract_from_pdf_llm_fallback(monkeypatch):
     def fake_parse(path, page_range=None):
         llm_calls.append({"path": path, "page_range": page_range})
         import pandas as pd
-        return pd.DataFrame({"Malzeme_Kodu": ["X"], "Descriptions": ["ItemZ"], "Fiyat": [55.0]})
+        return pd.DataFrame({"Malzeme_Kodu": ["X"], "Açıklama": ["ItemZ"], "Fiyat": [55.0]})
 
     import smart_price.core.extract_pdf as pdf_mod
     monkeypatch.setattr(pdf_mod.ocr_llm_fallback, "parse", fake_parse)
@@ -128,7 +128,7 @@ def test_extract_from_pdf_llm_fallback(monkeypatch):
     result = extract_from_pdf("dummy.pdf")
     assert len(result) == 1
     assert result.iloc[0]["Fiyat"] == 55.0
-    assert result.iloc[0]["Descriptions"] == "ItemZ"
+    assert result.iloc[0]["Açıklama"] == "ItemZ"
     assert len(llm_calls) == 1
 
 
@@ -203,7 +203,7 @@ def test_extract_from_pdf_llm_only(monkeypatch):
     def fake_parse(path, page_range=None):
         called['path'] = path
         import pandas as pd
-        return pd.DataFrame({"Descriptions": ["A"], "Fiyat": [1.0]})
+        return pd.DataFrame({"Açıklama": ["A"], "Fiyat": [1.0]})
 
     import sys
 
@@ -232,7 +232,7 @@ def test_extract_from_excel_xls(tmp_path):
     result = extract_from_excel(str(file))
     assert len(result) == 1
     assert result.iloc[0]["Fiyat"] == 1000.50
-    assert result["Descriptions"].tolist() == ["Elma"]
+    assert result["Açıklama"].tolist() == ["Elma"]
 
 
 def test_extract_from_excel_code_only(tmp_path):
@@ -247,7 +247,7 @@ def test_extract_from_excel_code_only(tmp_path):
 
     result = extract_from_excel(str(file))
     assert result["Malzeme_Kodu"].tolist() == ["C1", "D2"]
-    assert result["Descriptions"].tolist() == ["C1", "D2"]
+    assert result["Açıklama"].tolist() == ["C1", "D2"]
 
 
 def test_extract_from_excel_tip_header(tmp_path):
@@ -262,7 +262,7 @@ def test_extract_from_excel_tip_header(tmp_path):
 
     result = extract_from_excel(str(file))
     assert result["Malzeme_Kodu"].tolist() == ["C1", "D2"]
-    assert result["Descriptions"].tolist() == ["C1", "D2"]
+    assert result["Açıklama"].tolist() == ["C1", "D2"]
 
 
 def test_extract_from_excel_with_titles(tmp_path):
@@ -304,10 +304,10 @@ def test_extract_from_excel_bytesio():
     assert len(result) == 2
     assert result.iloc[0]["Fiyat"] == 1000.50
     assert result.iloc[1]["Fiyat"] == 2500.75
-    assert result["Descriptions"].tolist() == ["Elma", "Armut"]
+    assert result["Açıklama"].tolist() == ["Elma", "Armut"]
     expected_cols = [
         "Malzeme_Kodu",
-        "Descriptions",
+        "Açıklama",
         "Kisa_Kod",
         "Fiyat",
         "Para_Birimi",
@@ -336,7 +336,7 @@ def test_extract_from_excel_header_normalization(tmp_path):
 
     result = extract_from_excel(str(file))
     assert result.iloc[0]["Malzeme_Kodu"] == "001"
-    assert result["Descriptions"].tolist() == ["Elma"]
+    assert result["Açıklama"].tolist() == ["Elma"]
 
 def test_normalize_price_various_formats():
     assert normalize_price("1.234,56") == 1234.56
@@ -401,7 +401,7 @@ def test_extract_from_excel_brand_from_filename(tmp_path):
 
     result = extract_from_excel(str(file))
     assert result.iloc[0]["Marka"] == "Acme"
-    assert result["Descriptions"].tolist() == ["Elma"]
+    assert result["Açıklama"].tolist() == ["Elma"]
 
 
 def test_extract_from_excel_brand_filename_param():
@@ -418,7 +418,7 @@ def test_extract_from_excel_brand_filename_param():
 
     result = extract_from_excel(buf, filename="BrandX_prices.xlsx")
     assert result.iloc[0]["Marka"] == "BrandX"
-    assert result["Descriptions"].tolist() == ["Elma"]
+    assert result["Açıklama"].tolist() == ["Elma"]
 
 
 def test_extract_from_excel_brand_from_filename_multiword(tmp_path):
@@ -433,7 +433,7 @@ def test_extract_from_excel_brand_from_filename_multiword(tmp_path):
 
     result = extract_from_excel(str(file))
     assert result.iloc[0]["Marka"] == "Omega Motor"
-    assert result["Descriptions"].tolist() == ["Elma"]
+    assert result["Açıklama"].tolist() == ["Elma"]
 
 
 def test_extract_from_excel_short_code(tmp_path):
@@ -453,7 +453,7 @@ def test_extract_from_excel_short_code(tmp_path):
 
     result = extract_from_excel(str(file))
     assert result.iloc[0]["Kisa_Kod"] == "A1"
-    assert result["Descriptions"].tolist() == ["Elma"]
+    assert result["Açıklama"].tolist() == ["Elma"]
 
 
 def test_extract_from_excel_short_code_english_header(tmp_path):
@@ -473,7 +473,7 @@ def test_extract_from_excel_short_code_english_header(tmp_path):
 
     result = extract_from_excel(str(file))
     assert result.iloc[0]["Kisa_Kod"] == "BB"
-    assert result["Descriptions"].tolist() == ["Pear"]
+    assert result["Açıklama"].tolist() == ["Pear"]
 
 
 def test_extract_from_excel_default_currency(tmp_path):
@@ -489,7 +489,7 @@ def test_extract_from_excel_default_currency(tmp_path):
     result = extract_from_excel(str(file))
     assert result.iloc[0]["Para_Birimi"] == "TL"
     assert result.iloc[0]["Fiyat"] == 100.0
-    assert result["Descriptions"].tolist() == ["Elma"]
+    assert result["Açıklama"].tolist() == ["Elma"]
 
 
 def test_extract_from_pdf_default_currency(monkeypatch):
@@ -529,7 +529,7 @@ def test_extract_from_pdf_default_currency(monkeypatch):
     assert result.iloc[0]["Fiyat"] == 100.0
     expected_cols = [
         "Malzeme_Kodu",
-        "Descriptions",
+        "Açıklama",
         "Kisa_Kod",
         "Fiyat",
         "Para_Birimi",
@@ -586,7 +586,7 @@ def test_extract_from_pdf_table_headers(monkeypatch):
     assert result.iloc[1]["Fiyat"] == 2500.75
     expected_cols = [
         "Malzeme_Kodu",
-        "Descriptions",
+        "Açıklama",
         "Kisa_Kod",
         "Fiyat",
         "Para_Birimi",
@@ -655,7 +655,7 @@ def test_merge_files_casts_to_string(monkeypatch):
     df = pd.DataFrame(
         {
             "Malzeme_Kodu": [1, 2],
-            "Descriptions": ["A", "B"],
+            "Açıklama": ["A", "B"],
             "Kisa_Kod": [10, None],
             "Fiyat": [5, 6],
             "Para_Birimi": ["TL", "TL"],
@@ -687,7 +687,7 @@ def test_merge_files_pdf_called(monkeypatch):
     df = pd.DataFrame(
         {
             "Malzeme_Kodu": ["C1"],
-            "Descriptions": ["A"],
+            "Açıklama": ["A"],
             "Kisa_Kod": [None],
             "Fiyat": [5],
             "Para_Birimi": ["TL"],
@@ -729,21 +729,21 @@ def test_merge_files_dedup_by_code_and_price(monkeypatch):
     df_map = {
         "f1.xlsx": pd.DataFrame({
             "Malzeme_Kodu": ["X"],
-            "Descriptions": ["Item"],
+            "Açıklama": ["Item"],
             "Fiyat": [1.0],
             "Kaynak_Dosya": ["f1.xlsx"],
             "Ana_Baslik": ["T1"],
         }),
         "f2.xlsx": pd.DataFrame({
             "Malzeme_Kodu": ["X"],
-            "Descriptions": ["Item"],
+            "Açıklama": ["Item"],
             "Fiyat": [1.0],
             "Kaynak_Dosya": ["f2.xlsx"],
             "Ana_Baslik": ["T2"],
         }),
         "f3.xlsx": pd.DataFrame({
             "Malzeme_Kodu": ["X"],
-            "Descriptions": ["Item"],
+            "Açıklama": ["Item"],
             "Fiyat": [2.0],
             "Kaynak_Dosya": ["f3.xlsx"],
             "Ana_Baslik": ["T3"],
@@ -806,7 +806,7 @@ def test_llm_debug_files(monkeypatch, tmp_path):
     import smart_price.core.extract_pdf as pdf_mod
 
     def fake_parse(path, page_range=None):
-        return pd.DataFrame({"Malzeme_Kodu": ["X"], "Descriptions": ["A"], "Fiyat": [1.0]})
+        return pd.DataFrame({"Malzeme_Kodu": ["X"], "Açıklama": ["A"], "Fiyat": [1.0]})
 
     monkeypatch.setattr(pdf_mod.ocr_llm_fallback, "parse", fake_parse)
 
@@ -868,7 +868,7 @@ def test_extract_from_pdf_llm_sets_page_added(monkeypatch):
     def fake_parse(path, page_range=None):
         llm_calls.append({"path": path, "page_range": page_range})
         import pandas as pd
-        return pd.DataFrame({"Descriptions": ["X"], "Fiyat": [5.0]})
+        return pd.DataFrame({"Açıklama": ["X"], "Fiyat": [5.0]})
 
     monkeypatch.setattr(pdf_mod.ocr_llm_fallback, "parse", fake_parse)
 
@@ -889,7 +889,7 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
     sample_df = pd.DataFrame(
         {
             "Malzeme_Kodu": ["A1"],
-            "Descriptions": ["Item"],
+            "Açıklama": ["Item"],
             "Fiyat": [10.0],
             "Birim": ["ADET"],
             "Kutu_Adedi": ["5"],

--- a/tests/test_save_master_dataset.py
+++ b/tests/test_save_master_dataset.py
@@ -50,7 +50,7 @@ def test_save_master_new(tmp_path, monkeypatch):
     monkeypatch.setattr(streamlit_app, "upload_folder", lambda *_a, **_k: False)
     df = pd.DataFrame({
         'Malzeme_Kodu': ['A1'],
-        'Descriptions': ['Item'],
+        'Açıklama': ['Item'],
         'Fiyat': [1.0],
         'Kaynak_Dosya': ['new.xlsx'],
         'Marka': ['BrandA']
@@ -85,7 +85,7 @@ def test_save_master_update(tmp_path, monkeypatch):
     monkeypatch.setattr(streamlit_app, "upload_folder", lambda *_a, **_k: False)
     master = pd.DataFrame({
         'Malzeme_Kodu': ['X1', 'Y1'],
-        'Descriptions': ['Old', 'Keep'],
+        'Açıklama': ['Old', 'Keep'],
         'Fiyat': [2.0, 3.0],
         'Kaynak_Dosya': ['old.xlsx', 'keep.xlsx'],
         'Marka': ['BrandOld', 'BrandKeep'],
@@ -98,7 +98,7 @@ def test_save_master_update(tmp_path, monkeypatch):
 
     new = pd.DataFrame({
         'Malzeme_Kodu': ['Z1'],
-        'Descriptions': ['New'],
+        'Açıklama': ['New'],
         'Fiyat': [4.0],
         'Kaynak_Dosya': ['old.xlsx'],
         'Marka': ['BrandOld'],
@@ -118,5 +118,5 @@ def test_save_master_update(tmp_path, monkeypatch):
         rows = conn.execute("SELECT material_code, description FROM prices ORDER BY material_code").fetchall()
     assert rows == [("Y1", "Keep"), ("Z1", "New")]
     assert len(result) == 2
-    assert 'old.xlsx' not in result[result['Descriptions'] == 'Old']['Kaynak_Dosya'].values
+    assert 'old.xlsx' not in result[result['Açıklama'] == 'Old']['Kaynak_Dosya'].values
     assert not old_dir.exists()


### PR DESCRIPTION
## Summary
- rename `Descriptions` column to `Açıklama`
- update extraction modules and Streamlit apps for the new field
- adjust CLI DB writing logic
- fix tests for the renamed column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683df6b1ad08832f989a2fe37fd93836