### PR TITLE
Add main_header and sub_header columns

### DIFF
--- a/Price App/smart_price/price_parser.py
+++ b/Price App/smart_price/price_parser.py
@@ -158,8 +158,8 @@ def main() -> None:
             record_code TEXT,
             year INTEGER,
             brand TEXT,
-            main_title TEXT,
-            sub_title TEXT,
+            main_header TEXT,
+            sub_header TEXT,
             category TEXT
             )"""
         )
@@ -177,8 +177,8 @@ def main() -> None:
                 "Record_Code": "record_code",
                 "Yil": "year",
                 "Marka": "brand",
-                "Ana_Baslik": "main_title",
-                "Alt_Baslik": "sub_title",
+                "Ana_Baslik": "main_header",
+                "Alt_Baslik": "sub_header",
                 "Kategori": "category",
             },
             inplace=True,
@@ -196,8 +196,8 @@ def main() -> None:
             "record_code",
             "year",
             "brand",
-            "main_title",
-            "sub_title",
+            "main_header",
+            "sub_header",
             "category",
         ]:
             if col not in master.columns:
@@ -216,8 +216,8 @@ def main() -> None:
             "record_code",
             "year",
             "brand",
-            "main_title",
-            "sub_title",
+            "main_header",
+            "sub_header",
             "category",
         ]
         ]

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -290,8 +290,8 @@ def save_master_dataset(
             record_code TEXT,
             year INTEGER,
             brand TEXT,
-            main_title TEXT,
-            sub_title TEXT,
+            main_header TEXT,
+            sub_header TEXT,
             category TEXT
             )"""
         )
@@ -310,8 +310,8 @@ def save_master_dataset(
                 "Record_Code": "record_code",
                 "Yil": "year",
                 "Marka": "brand",
-                "Ana_Baslik": "main_title",
-                "Alt_Baslik": "sub_title",
+                "Ana_Baslik": "main_header",
+                "Alt_Baslik": "sub_header",
                 "Kategori": "category",
             },
             inplace=True,
@@ -329,8 +329,8 @@ def save_master_dataset(
             "record_code",
             "year",
             "brand",
-            "main_title",
-            "sub_title",
+            "main_header",
+            "sub_header",
             "category",
         ]:
             if col not in db_df.columns:
@@ -348,11 +348,11 @@ def save_master_dataset(
                 "image_path",
                 "record_code",
                 "year",
-                "brand",
-                "main_title",
-                "sub_title",
-                "category",
-            ]
+            "brand",
+            "main_header",
+            "sub_header",
+            "category",
+        ]
         ]
         db_df.to_sql("prices", conn, if_exists="replace", index=False)
     conn.close()

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ smart-price-parser data/list.xlsx another.pdf -o merged_prices.xlsx
 The parser writes its results to `output/` by default. Set `OUTPUT_DIR` to
 change this location or specify `OUTPUT_EXCEL`, `OUTPUT_DB` and `OUTPUT_LOG`
 to override each individual path.
+The resulting SQLite database contains `main_header` and `sub_header`
+columns to store any detected section headings.
 
 ### Running the Streamlit interface
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -936,8 +936,8 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
         "record_code",
         "year",
         "brand",
-        "main_title",
-        "sub_title",
+        "main_header",
+        "sub_header",
         "category",
     ]
     cur.execute("SELECT * FROM prices")

--- a/tests/test_save_master_dataset.py
+++ b/tests/test_save_master_dataset.py
@@ -67,7 +67,7 @@ def test_save_master_new(tmp_path, monkeypatch):
     assert streamlit_app.config.MASTER_DB_PATH.exists()
     with sqlite3.connect(streamlit_app.config.MASTER_DB_PATH) as conn:
         rows = conn.execute(
-            "SELECT material_code, description, price, brand, main_title, sub_title FROM prices"
+            "SELECT material_code, description, price, brand, main_header, sub_header FROM prices"
         ).fetchall()
     assert rows == [("A1", "Item", 1.0, "BrandA", None, None)]
     assert len(saved) == 1


### PR DESCRIPTION
## Summary
- expand DB schema with `main_header` and `sub_header` columns
- propagate new column names to `streamlit_app` and `price_parser`
- adjust tests for new schema
- document the new fields in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dfa46e308832f92247ba299eb7e74