### PR TITLE
Update tests for new prompt and DataFrame columns

### DIFF
--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -182,7 +182,7 @@ def test_llm_prompt_and_clean(monkeypatch):
 
     result = func('sample')
     assert cleaned == ['[{"name":"A","price":"4"}]']
-    assert 'PDF fiyat listesi analiz asistanısın' in captured_prompt[0]
+    assert 'Extraction_guide Kullanımı' in captured_prompt[0]
     assert result == [{
         'Malzeme_Adi': 'A',
         'Fiyat': 4.0,

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -76,6 +76,7 @@ def test_extract_from_excel_basic(tmp_path):
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Sayfa",
         "Record_Code",
         "Ana_Baslik",
         "Alt_Baslik",
@@ -313,6 +314,7 @@ def test_extract_from_excel_bytesio():
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Sayfa",
         "Record_Code",
         "Ana_Baslik",
         "Alt_Baslik",
@@ -535,9 +537,11 @@ def test_extract_from_pdf_default_currency(monkeypatch):
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Sayfa",
         "Record_Code",
         "Ana_Baslik",
         "Alt_Baslik",
+        "Image_Path",
     ]
     assert result.columns.tolist() == expected_cols
 
@@ -592,9 +596,11 @@ def test_extract_from_pdf_table_headers(monkeypatch):
         "Para_Birimi",
         "Marka",
         "Kaynak_Dosya",
+        "Sayfa",
         "Record_Code",
         "Ana_Baslik",
         "Alt_Baslik",
+        "Image_Path",
     ]
     assert result.columns.tolist() == expected_cols
 

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from smart_price.core import prompt_utils
+from smart_price import config
+
+
+def test_load_extraction_guide_csv(tmp_path):
+    path = tmp_path / "guide.csv"
+    path.write_text("pdf,page,prompt\ndummy.pdf,1,HELLO\n")
+    data = prompt_utils.load_extraction_guide(str(path))
+    assert data == [{"pdf": "dummy.pdf", "page": "1", "prompt": "HELLO"}]
+
+
+def test_load_extraction_guide_json(tmp_path):
+    path = tmp_path / "guide.json"
+    path.write_text('[{"pdf":"dummy.pdf","page":2,"prompt":"HI"}]')
+    data = prompt_utils.load_extraction_guide(str(path))
+    assert data == [{"pdf": "dummy.pdf", "page": 2, "prompt": "HI"}]
+
+
+def test_load_extraction_guide_bad(tmp_path, monkeypatch):
+    path = tmp_path / "bad.csv"
+    path.write_text("not,really")
+    monkeypatch.setattr(config, "EXTRACTION_GUIDE_PATH", path)
+    # parsing should fail and return empty list
+    assert prompt_utils.load_extraction_guide() == []
+
+
+def test_prompts_for_pdf(tmp_path):
+    path = tmp_path / "guide.csv"
+    path.write_text("pdf,page,prompt\ndummy.pdf,,ALL\ndummy.pdf,2,TWO\n")
+    mapping = prompt_utils.prompts_for_pdf("dummy.pdf", str(path))
+    assert mapping == {0: "ALL", 2: "TWO"}
+
+
+def test_prompts_for_pdf_no_match(tmp_path):
+    path = tmp_path / "guide.csv"
+    path.write_text("pdf,page,prompt\nother.pdf,1,HELLO\n")
+    assert prompt_utils.prompts_for_pdf("dummy.pdf", str(path)) is None


### PR DESCRIPTION
## Summary
- adapt prompt expectation in LLM tests
- update expected column lists for extractors
- add tests covering extraction_guide utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dfbb05668832fa3733446ac7157ff