### PR TITLE
Clarify Poppler placeholder files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@ pip install .
 The tools attempt to locate the `tesseract` executable automatically using `shutil.which`. If `TESSDATA_PREFIX` is already defined it is respected, otherwise the location of the bundled language files is guessed from the executable path. When `tesseract` cannot be found a Windows default of `D:\Program Files\Tesseract-OCR` is used.
 
 The Poppler utilities `pdftoppm.exe`, `pdftocairo.exe` and `pdfinfo.exe` are
-also required for PDF processing. They are bundled in the `poppler/bin`
-directory.
+also required for PDF processing. The repository only contains placeholder
+files in the `poppler/bin` directory, so download the real executables and
+replace the placeholders before running the tools.
+
+### Poppler setup
+
+Download Poppler for Windows (64-bit) and copy `pdftoppm.exe`,
+`pdftocairo.exe` and `pdfinfo.exe` into `poppler/bin`.
 
 PDF files are parsed entirely through GPT‑4o Vision. Each page image is generated with **pdf2image** and sent to the model with a Turkish prompt. The response contains structured JSON for the rows.
 
@@ -48,10 +54,9 @@ once the executable is launched.  It also adds the `logo` folder to ensure
 the images used by the interface are packaged together with the `.streamlit`
 configuration folder.  The resulting binary will appear in the `dist` folder.
 Both Poppler and Tesseract binaries are bundled from the `poppler/bin` folder
-so no separate installation is required.  This directory now also contains
-`pdfinfo.exe` from the same Poppler release as `pdftoppm.exe` and
-`pdftocairo.exe`.  If you store these tools elsewhere
-edit `POPLPLERDIR` (and set `TESSERACT_CMD` if needed) in
+so the resulting EXE runs without additional dependencies. Place the actual
+`pdftoppm.exe`, `pdftocairo.exe` and `pdfinfo.exe` files there first.  If you
+store these tools elsewhere edit `POPLPLERDIR` (and set `TESSERACT_CMD` if needed) in
 `build_windows_exe.bat` to point to the correct paths.  The batch file
 collects all Streamlit resources so the executable launches without a
 `PackageNotFoundError` for the `streamlit` distribution. The launcher script


### PR DESCRIPTION
## Summary
- clarify that `poppler/bin` only contains placeholders
- instruct users to download Poppler for Windows and copy the real executables
- update Windows build instructions accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e06ff3da0832fbf2c4750fc4037fb