### PR TITLE
Restore automatic browser launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ store these tools elsewhere edit `POPLPLERDIR` (and set `TESSERACT_CMD` if neede
 `build_windows_exe.bat` to point to the correct paths.  The batch file
 collects all Streamlit resources so the executable launches without a
 `PackageNotFoundError` for the `streamlit` distribution. The launcher script
-sets `STREAMLIT_SERVER_PORT=8501` and `STREAMLIT_SERVER_HEADLESS=true` to
-ensure the app listens on the usual port when run from the generated EXE.
+sets `STREAMLIT_SERVER_PORT=8501` and `STREAMLIT_SERVER_HEADLESS=false` so the
+browser opens automatically when the app is started from the generated EXE.
 
 ### Price normalization
 

--- a/run_app.py
+++ b/run_app.py
@@ -4,7 +4,8 @@ import pathlib
 
 # Ensure a consistent Streamlit configuration when packaged
 os.environ["STREAMLIT_SERVER_PORT"] = "8501"
-os.environ["STREAMLIT_SERVER_HEADLESS"] = "true"
+# Launch Streamlit with a browser tab when the app starts
+os.environ["STREAMLIT_SERVER_HEADLESS"] = "false"
 # Disable development mode to allow custom ports when packaged
 os.environ["STREAMLIT_GLOBAL_DEVELOPMENT_MODE"] = "false"
 try:


### PR DESCRIPTION
## Summary
- allow Streamlit to launch the browser by default
- document the updated setting in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e9a04c684832f954d789160580a47