### PR TITLE
Normalize currency values across extractors

### DIFF
--- a/Price App/smart_price/core/common_utils.py
+++ b/Price App/smart_price/core/common_utils.py
@@ -64,6 +64,27 @@ def detect_currency(text: str) -> Optional[str]:
     return None
 
 
+def normalize_currency(value: Optional[str]) -> Optional[str]:
+    """Return a single currency symbol for ``value``."""
+    if not value:
+        return None
+    mapping = {
+        "TL": "₺",
+        "TRY": "₺",
+        "₺": "₺",
+        "USD": "$",
+        "$": "$",
+        "EUR": "€",
+        "€": "€",
+    }
+    key = str(value).strip().upper()
+    if key in mapping:
+        return mapping[key]
+    if value in mapping:
+        return mapping[value]
+    return None
+
+
 def select_latest_year_column(df, pattern: str = r"(\d{4})") -> Optional[str]:
     """Return the column name containing the latest year according to pattern."""
     year_cols = {}

--- a/Price App/smart_price/core/extract_excel.py
+++ b/Price App/smart_price/core/extract_excel.py
@@ -14,6 +14,7 @@ from .common_utils import (
     select_latest_year_column,
     detect_currency,
     detect_brand,
+    normalize_currency,
 )
 
 logger = logging.getLogger("smart_price")
@@ -229,8 +230,8 @@ def extract_from_excel(
                 sheet_data.rename(columns=mapping, inplace=True)
                 if "Para_Birimi" not in sheet_data.columns:
                     sheet_data["Para_Birimi"] = sheet_data["Fiyat_Ham"].astype(str).apply(detect_currency)
-                # Default to Turkish Lira if currency could not be determined
-                sheet_data["Para_Birimi"] = sheet_data["Para_Birimi"].fillna("TL")
+                sheet_data["Para_Birimi"] = sheet_data["Para_Birimi"].apply(normalize_currency)
+                sheet_data["Para_Birimi"] = sheet_data["Para_Birimi"].fillna("₺")
                 sheet_data["Kaynak_Dosya"] = _basename(filepath, filename)
                 brand_from_file = detect_brand(_basename(filepath, filename))
                 year_match = None

--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -29,6 +29,7 @@ import re
 from .common_utils import (
     normalize_price,
     detect_currency,
+    normalize_currency,
     detect_brand,
     gpt_clean_text,
     safe_json_parse,
@@ -261,7 +262,7 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
                     {
                         "Malzeme_Adi": name,
                         "Fiyat": val,
-                        "Para_Birimi": detect_currency(price_raw),
+                        "Para_Birimi": normalize_currency(detect_currency(price_raw)),
                     }
                 )
         count = len(results)
@@ -325,7 +326,8 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
         upload_folder(debug_dir, remote_prefix=f"LLM_Output_db/{debug_dir.name}")
         return result
 
-    result["Para_Birimi"] = result["Para_Birimi"].fillna("TL")
+    result["Para_Birimi"] = result["Para_Birimi"].apply(normalize_currency)
+    result["Para_Birimi"] = result["Para_Birimi"].fillna("₺")
     result["Kaynak_Dosya"] = _basename(filepath, filename)
     result["Yil"] = None
     brand_from_file = detect_brand(_basename(filepath, filename))

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -30,6 +30,7 @@ from .common_utils import (
     gpt_clean_text,
     normalize_price,
     detect_currency,
+    normalize_currency,
     safe_json_parse,
 )
 from .debug_utils import save_debug, save_debug_image, set_output_subdir
@@ -284,6 +285,7 @@ def parse(
             para_birimi = item.get("Para_Birimi") or item.get("Para Birimi")
             if para_birimi is None:
                 para_birimi = detect_currency(price_raw)
+            para_birimi = normalize_currency(para_birimi)
             page_rows.append(
                 {
                     "Malzeme_Kodu": code,
@@ -339,6 +341,11 @@ def parse(
     except Exception:
         row_count = len(rows)
     logger.debug("[%s] DataFrame oluşturuldu: %d satır", pdf_path, row_count)
+    if hasattr(df, "columns"):
+        if "Para_Birimi" not in df.columns:
+            df["Para_Birimi"] = None
+        df["Para_Birimi"] = df["Para_Birimi"].apply(normalize_currency)
+        df["Para_Birimi"] = df["Para_Birimi"].fillna("₺")
     if hasattr(df, "columns"):
         if "Ana_Baslik" not in df.columns:
             df["Ana_Baslik"] = None

--- a/Price App/smart_price/parsers.py
+++ b/Price App/smart_price/parsers.py
@@ -10,6 +10,7 @@ from .core.common_utils import (
     normalize_price,
     detect_currency,
     detect_brand,
+    normalize_currency,
 )
 
 
@@ -58,7 +59,8 @@ def parse_df(df: pd.DataFrame) -> pd.DataFrame:
 
     if "Para_Birimi" not in data.columns:
         data["Para_Birimi"] = data["Fiyat_Ham"].astype(str).apply(detect_currency)
-    data["Para_Birimi"] = data["Para_Birimi"].fillna("TL")
+    data["Para_Birimi"] = data["Para_Birimi"].apply(normalize_currency)
+    data["Para_Birimi"] = data["Para_Birimi"].fillna("₺")
 
     year_match = None
     if price_col:

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -31,6 +31,7 @@ from smart_price.core.extract_pdf import extract_from_pdf, MIN_CODE_RATIO
 from smart_price import config
 from smart_price.core.logger import init_logging
 from smart_price.core.github_upload import upload_folder, delete_github_folder
+from smart_price.core.common_utils import normalize_currency
 
 logger = logging.getLogger("smart_price")
 
@@ -250,6 +251,10 @@ def save_master_dataset(
     excel_path = os.path.abspath(str(config.MASTER_EXCEL_PATH))
     db_path = os.path.abspath(str(config.MASTER_DB_PATH))
     os.makedirs(os.path.dirname(excel_path), exist_ok=True)
+    if "Para_Birimi" not in df.columns:
+        df["Para_Birimi"] = None
+    df["Para_Birimi"] = df["Para_Birimi"].apply(normalize_currency)
+    df["Para_Birimi"] = df["Para_Birimi"].fillna("₺")
     existing = pd.DataFrame()
     if os.path.exists(excel_path):
         try:

--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -112,7 +112,7 @@ def test_llm_extract_valid_json(monkeypatch):
     assert result == [{
         'Malzeme_Adi': 'Item',
         'Fiyat': 10.0,
-        'Para_Birimi': 'TRY'
+        'Para_Birimi': '₺'
     }]
     assert logs[0].startswith("LLM fazı başladı")
     assert logs[-1] == "LLM parsed 1 items"
@@ -127,7 +127,7 @@ def test_llm_extract_extra_text(monkeypatch):
     assert result == [{
         'Malzeme_Adi': 'Foo',
         'Fiyat': 5.0,
-        'Para_Birimi': 'USD'
+        'Para_Birimi': '$'
     }]
     assert logs[0].startswith("LLM fazı başladı")
     assert logs[-1] == "LLM parsed 1 items"
@@ -199,6 +199,6 @@ def test_llm_extract_mismatched_quotes(monkeypatch):
     assert result == [{
         'Malzeme_Adi': 'Foo',
         'Fiyat': 5.0,
-        'Para_Birimi': 'USD'
+        'Para_Birimi': '$'
     }]
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -489,7 +489,7 @@ def test_extract_from_excel_default_currency(tmp_path):
     df.to_excel(file, index=False)
 
     result = extract_from_excel(str(file))
-    assert result.iloc[0]["Para_Birimi"] == "TL"
+    assert result.iloc[0]["Para_Birimi"] == "₺"
     assert result.iloc[0]["Fiyat"] == 100.0
     assert result["Açıklama"].tolist() == ["Elma"]
 
@@ -527,7 +527,7 @@ def test_extract_from_pdf_default_currency(monkeypatch):
 
     result = extract_from_pdf("dummy.pdf")
     assert len(result) == 1
-    assert result.iloc[0]["Para_Birimi"] == "TL"
+    assert result.iloc[0]["Para_Birimi"] == "₺"
     assert result.iloc[0]["Fiyat"] == 100.0
     expected_cols = [
         "Malzeme_Kodu",
@@ -664,7 +664,7 @@ def test_merge_files_casts_to_string(monkeypatch):
             "Açıklama": ["A", "B"],
             "Kisa_Kod": [10, None],
             "Fiyat": [5, 6],
-            "Para_Birimi": ["TL", "TL"],
+            "Para_Birimi": ["₺", "₺"],
             "Marka": [None, None],
             "Kaynak_Dosya": ["f.xlsx", "f.xlsx"],
         }
@@ -696,7 +696,7 @@ def test_merge_files_pdf_called(monkeypatch):
             "Açıklama": ["A"],
             "Kisa_Kod": [None],
             "Fiyat": [5],
-            "Para_Birimi": ["TL"],
+            "Para_Birimi": ["₺"],
             "Marka": [None],
             "Kaynak_Dosya": ["f.pdf"],
             "Ana_Baslik": ["M"],
@@ -899,7 +899,7 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
             "Fiyat": [10.0],
             "Birim": ["ADET"],
             "Kutu_Adedi": ["5"],
-            "Para_Birimi": ["TL"],
+            "Para_Birimi": ["₺"],
             "Kaynak_Dosya": ["src.xlsx"],
             "Sayfa": [1],
             "Image_Path": ["img.png"],
@@ -954,7 +954,7 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
         10.0,
         "ADET",
         "5",
-        "TL",
+        "₺",
         "src.xlsx",
         1,
         "img.png",


### PR DESCRIPTION
## Summary
- add `normalize_currency` helper to map codes or strings to consistent symbols
- use the helper in Excel/PDF extraction, parsers and OCR fallback
- ensure master dataset saves normalized currency values
- update tests to expect currency symbols

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ea90be024832fade492f78f1fe1c5