### PR TITLE
Fix agentic_doc parse usage

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -56,7 +56,7 @@ def extract_from_pdf_agentic(
         os.environ.setdefault("VISION_AGENT_API_KEY", api_key)
 
     try:
-        import agentic_doc
+        from agentic_doc.parse import parse
     except Exception as exc:  # pragma: no cover - optional dependency missing
         notify(f"agentic_doc import failed: {exc}", "error")
         return pd.DataFrame()
@@ -66,9 +66,9 @@ def extract_from_pdf_agentic(
     guide_prompt = prompts_for_pdf(os.path.basename(src))
 
     try:
-        result = agentic_doc.parse(filepath, prompt=guide_prompt)
+        result = parse(filepath, prompt=guide_prompt)
     except TypeError:
-        result = agentic_doc.parse(filepath)
+        result = parse(filepath)
     except Exception as exc:
         notify(f"agentic_doc.parse failed: {exc}", "error")
         logger.exception("agentic_doc.parse failed")


### PR DESCRIPTION
## Summary
- use correct import for `agentic_doc.parse`
- call `parse()` directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f2da982ac832f8d7a7c0c4cf01687