### PR TITLE
Handle list output from agentic_doc.parse

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -42,6 +42,11 @@ def extract_from_pdf_agentic(
     -------
     pandas.DataFrame
         DataFrame with the same columns as :func:`extract_from_pdf`.
+
+    Notes
+    -----
+    ``agentic_doc.parse`` returns a list of ``ParsedDocument`` objects.
+    This function uses only the first document in that list.
     """
     def notify(message: str, level: str = "info") -> None:
         logger.info(message)
@@ -73,6 +78,13 @@ def extract_from_pdf_agentic(
         notify(f"agentic_doc.parse failed: {exc}", "error")
         logger.exception("agentic_doc.parse failed")
         return pd.DataFrame()
+
+    if isinstance(result, list):
+        if result:
+            result = result[0]
+        else:
+            notify("agentic_doc.parse returned no documents", "warning")
+            return pd.DataFrame()
 
     chunks = getattr(result, "chunks", [])
     df = pd.DataFrame(list(chunks) if chunks is not None else [])

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ under **PDF extraction method** to activate this workflow. Both parsing
 pipelines currently use the same prompt structure, so results should be
 comparable.
 
+``agentic_doc.parse`` now returns a list of ``ParsedDocument`` objects. The
+tools use the first item in that list.
+
 ### Building a Windows executable
 
 You can package the Streamlit interface into a single Windows executable using

--- a/tests/test_agentic_parse.py
+++ b/tests/test_agentic_parse.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import types
+import importlib
+import pytest
+
+try:
+    import pandas as pd  # noqa: F401
+    HAS_PANDAS = True
+except ModuleNotFoundError:
+    HAS_PANDAS = False
+
+if HAS_PANDAS:
+    from smart_price.core.extract_pdf_agentic import extract_from_pdf_agentic
+else:
+    extract_from_pdf_agentic = None
+
+
+@pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
+def test_agentic_parse_list(monkeypatch):
+    parsed_doc = types.SimpleNamespace(
+        chunks=[{"Malzeme_Kodu": "A", "Açıklama": "Item", "Fiyat": 1.0}],
+        page_summary=[{"page_number": 1, "rows": 1, "status": "success", "note": None}],
+        token_counts={"input": 1, "output": 1},
+    )
+
+    parse_mod = types.ModuleType("agentic_doc.parse")
+    parse_mod.parse = lambda *_a, **_kw: [parsed_doc]
+    agentic_pkg = types.ModuleType("agentic_doc")
+    agentic_pkg.__path__ = []
+    agentic_pkg.parse = parse_mod
+    monkeypatch.setitem(sys.modules, "agentic_doc", agentic_pkg)
+    monkeypatch.setitem(sys.modules, "agentic_doc.parse", parse_mod)
+
+    mod = importlib.import_module("smart_price.core.extract_pdf_agentic")
+    importlib.reload(mod)
+
+    df = mod.extract_from_pdf_agentic("dummy.pdf")
+    assert len(df) == 1
+    assert df.iloc[0]["Malzeme_Kodu"] == "A"
+    assert getattr(df, "page_summary", None) == parsed_doc.page_summary
+    assert getattr(df, "token_counts", None) == parsed_doc.token_counts


### PR DESCRIPTION
## Summary
- update agentic PDF parser to handle new list return type from `agentic_doc.parse`
- document this behaviour in `README.md`
- add regression test for the list output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f32a00d54832f8e81277a8ad3ad0e