### PR TITLE
Improve Agentic parser logging

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -79,6 +79,11 @@ def extract_from_pdf_agentic(
         logger.exception("agentic_doc.parse failed")
         return pd.DataFrame()
 
+    notify(f"{src}: parse returned {type(result).__name__}")
+    summary = getattr(result, "page_summary", None)
+    if summary is not None:
+        notify(f"{src}: page_summary {summary}")
+
     if isinstance(result, list):
         if result:
             result = result[0]
@@ -96,6 +101,10 @@ def extract_from_pdf_agentic(
     token_counts = getattr(result, "token_counts", None)
     if token_counts is not None and hasattr(df, "__dict__"):
         object.__setattr__(df, "token_counts", token_counts)
+
+    if df.empty:
+        pages = len(page_summary) if page_summary is not None else 0
+        notify(f"{src}: no rows extracted from {pages} pages", "warning")
 
     notify(f"agentic_doc returned {len(df)} rows")
 

--- a/README.md
+++ b/README.md
@@ -194,3 +194,8 @@ and an excerpt of the prompt. This can help diagnose why the extraction failed.
 
 The prompt length and raw response are always logged to help troubleshoot
 unexpected LLM behaviour.
+
+When the AgenticDE workflow is used, the log also notes the type of object
+returned by ``agentic_doc.parse`` and dumps any ``page_summary`` entries. If no
+rows are produced a warning records how many pages were processed. All these
+messages include the source PDF name.


### PR DESCRIPTION
## Summary
- log return type and page summary for the agentic parser
- warn when no rows are produced with the page count
- document new diagnostics in Troubleshooting section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f35a5b99c832faa655e28f0afe082