### PR TITLE
Improve agentic_doc error logging

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -76,6 +76,20 @@ def extract_from_pdf_agentic(
         result = parse(filepath)
     except Exception as exc:
         notify(f"agentic_doc.parse failed: {exc}", "error")
+        status = getattr(exc, "status", None) or getattr(exc, "status_code", None)
+        response = getattr(exc, "response", None)
+        if response is not None:
+            status = status or getattr(response, "status", None) or getattr(response, "status_code", None)
+            try:
+                body = getattr(response, "text", None) or getattr(response, "content", None)
+            except Exception:
+                body = None
+            if body:
+                notify(f"response: {body}", "error")
+                logger.error("response: %s", body)
+        if status is not None:
+            notify(f"status code: {status}", "error")
+            logger.error("status code: %s", status)
         logger.exception("agentic_doc.parse failed")
         return pd.DataFrame()
 

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -198,7 +198,10 @@ def merge_files(
                     status_log=update_status,
                     method=method,
                 )
-        except Exception:
+        except Exception as exc:
+            logger.exception("Extraction failed for %s", up_file.name)
+            if update_status:
+                update_status(f"veri çıkarılamadı: {exc}", "error")
             df = pd.DataFrame()
 
         if df.empty:

--- a/README.md
+++ b/README.md
@@ -220,3 +220,6 @@ When the AgenticDE workflow is used, the log also notes the type of object
 returned by ``agentic_doc.parse`` and dumps any ``page_summary`` entries. If no
 rows are produced a warning records how many pages were processed. All these
 messages include the source PDF name.
+Errors raised by ``agentic_doc`` now log the HTTP status code, full response
+text and exception details to help diagnose rate limit, authentication or
+parsing issues.


### PR DESCRIPTION
## Summary
- log agentic_doc HTTP status and response text on failures
- surface extraction errors in the Streamlit app
- document the new detailed error logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683f37641518832f87c75afdfbd01704