### PR TITLE
Improve header normalization

### DIFF
--- a/Price App/smart_price/core/extract_excel.py
+++ b/Price App/smart_price/core/extract_excel.py
@@ -52,6 +52,10 @@ _RAW_DESC_HEADERS = [
     "description",
     "ürün açıklaması",
     "açıklama",
+    "aciklama",
+    "özellikler",
+    "detay",
+    "explanation",
 ]
 
 POSSIBLE_CODE_HEADERS = set(_RAW_CODE_HEADERS)

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -26,7 +26,13 @@ right_logo_url = (
     "https://raw.githubusercontent.com/muratturan19/Smart_Price/main/logo/sadece_dp_seffaf.PNG"
 )
 
-from smart_price.core.extract_excel import extract_from_excel
+from smart_price.core.extract_excel import (
+    extract_from_excel,
+    _norm_header,
+    _NORMALIZED_CODE_HEADERS,
+    POSSIBLE_DESC_HEADERS,
+    POSSIBLE_PRICE_HEADERS,
+)
 from smart_price.core.extract_pdf import extract_from_pdf, MIN_CODE_RATIO
 from smart_price.core.extract_pdf_agentic import extract_from_pdf_agentic
 from smart_price import config
@@ -41,29 +47,15 @@ def standardize_column_names(df: pd.DataFrame) -> pd.DataFrame:
     """Return ``df`` with common column name variants normalised."""
     mapping = {}
     for col in df.columns:
-        norm = str(col).replace("_", " ").casefold()
-        if norm in {
-            "fiyat",
-            "birim fiyat",
-            "liste fiyatı",
-            "price",
-            "unit price",
-            "list price",
-            "tutar",
-            "fiyat ham",
-        }:
+        norm = _norm_header(col)
+        if norm in POSSIBLE_PRICE_HEADERS:
             mapping[col] = "Fiyat"
-        elif norm in {
-            "malzeme kodu",
-            "urun kodu",
-            "ürün kodu",
-            "kod",
-            "product code",
-            "part no",
-            "item no",
-            "item number",
-        }:
+        elif norm in _NORMALIZED_CODE_HEADERS:
             mapping[col] = "Malzeme_Kodu"
+        elif norm in POSSIBLE_DESC_HEADERS or any(
+            term in norm for term in {"ozellik", "detay", "explanation"}
+        ):
+            mapping[col] = "Açıklama"
     if mapping:
         df = df.rename(columns=mapping)
     return df

--- a/tests/test_standardize_columns.py
+++ b/tests/test_standardize_columns.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+try:
+    import pandas as pd  # noqa: F401
+    HAS_PANDAS = hasattr(pd, "DataFrame")
+except ModuleNotFoundError:
+    HAS_PANDAS = False
+    stub = types.ModuleType("pandas")
+    stub.DataFrame = type("DataFrame", (), {})
+    sys.modules["pandas"] = stub
+
+if HAS_PANDAS:
+    from smart_price import streamlit_app
+else:
+    streamlit_app = None
+
+
+@pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
+def test_standardize_desc_column():
+    import pandas as pd
+    df = pd.DataFrame({
+        "Detay": ["Item"],
+        "Fiyat": [1.0],
+        "Malzeme Kodu": ["A1"],
+    })
+    result = streamlit_app.standardize_column_names(df)
+    assert "Açıklama" in result.columns
+    assert result["Açıklama"].tolist() == ["Item"]


### PR DESCRIPTION
## Summary
- extend RAW_DESC_HEADERS with more description keywords
- normalize column names using header sets from extract_excel
- add regression test for standardize_column_names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684050160c00832f9c5741f6e774d21b