### PR TITLE
Fix missing description column

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -271,8 +271,14 @@ def merge_files(
     if before_len != len(master):
         logger.debug("[merge] Drop nedeni: subset=['Malzeme_Kodu', 'Fiyat']")
         logger.debug("[merge] Drop edilen ilk 5 satır: %s", dropped_preview)
-    master["Açıklama"] = master["Açıklama"].astype(str).str.strip().str.upper()
-    master.sort_values(by="Açıklama", inplace=True)
+    if "Açıklama" in master.columns:
+        master["Açıklama"] = (
+            master["Açıklama"].astype(str).str.strip().str.upper()
+        )
+        master.sort_values(by="Açıklama", inplace=True)
+    else:
+        logger.warning("[merge] 'Açıklama' column missing after merge")
+        master["Açıklama"] = None
     if "Kisa_Kod" in master.columns:
         master["Kisa_Kod"] = master["Kisa_Kod"].astype(str)
     if "Malzeme_Kodu" in master.columns:


### PR DESCRIPTION
## Summary
- avoid `KeyError: 'Açıklama'` when merging files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68406787cd18832fbd94c02de88e5f0d