### PR TITLE
Fix agentic_doc header mapping

### DIFF
--- a/tests/test_agentic_parse.py
+++ b/tests/test_agentic_parse.py
@@ -40,3 +40,28 @@ def test_agentic_parse_list(monkeypatch):
     assert df.iloc[0]["Malzeme_Kodu"] == "A"
     assert getattr(df, "page_summary", None) == parsed_doc.page_summary
     assert getattr(df, "token_counts", None) == parsed_doc.token_counts
+
+
+@pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
+def test_agentic_numeric_headers(monkeypatch):
+    parsed_doc = types.SimpleNamespace(
+        chunks=[{0: "A1", 1: "Desc", 2: "5"}],
+        page_summary=[{"page_number": 1, "rows": 1, "status": "success"}],
+        token_counts={"input": 1, "output": 1},
+    )
+
+    parse_mod = types.ModuleType("agentic_doc.parse")
+    parse_mod.parse = lambda *_a, **_kw: [parsed_doc]
+    agentic_pkg = types.ModuleType("agentic_doc")
+    agentic_pkg.__path__ = []
+    agentic_pkg.parse = parse_mod
+    monkeypatch.setitem(sys.modules, "agentic_doc", agentic_pkg)
+    monkeypatch.setitem(sys.modules, "agentic_doc.parse", parse_mod)
+
+    mod = importlib.import_module("smart_price.core.extract_pdf_agentic")
+    importlib.reload(mod)
+
+    df = mod.extract_from_pdf_agentic("dummy.pdf")
+    assert list(df.columns)[:3] == ["Malzeme_Kodu", "Açıklama", "Fiyat"]
+    assert df.iloc[0]["Malzeme_Kodu"] == "A1"
+    assert df.iloc[0]["Açıklama"] == "Desc"


### PR DESCRIPTION
## Summary
- map numeric columns returned by `agentic_doc.parse` to standard header names
- test numeric header handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684075fdbd90832f83ce7b618e1a3e7f