### PR TITLE
Handle optional agentic-doc library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . ruff black pytest coverage pyinstaller
+          pip install .[agentic] ruff black pytest coverage pyinstaller
       - name: Ruff
         run: ruff .
       - name: Black
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . pyinstaller
+          pip install .[agentic] pyinstaller
       - name: Build
         run: ./build_windows_exe.bat
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The required Python packages are listed in `pyproject.toml`. Install them togeth
 
 ```bash
 pip install .
+pip install .[agentic]  # optional AgenticDE support
 ```
 
 `tkinter` must also be available. It is typically included with many Python distributions but may require a separate installation on some systems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 where = ["Price App", "Sales App"]
 
 [project.optional-dependencies]
-agentic = ["agentic-doc"]
+agentic = ["agentic-doc>=0.2.3"]
 
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- adapt extract_pdf_agentic to optional `agentic-doc`
- pin `agentic-doc>=0.2.3` in optional extras
- install optional extras in CI
- document extras installation in README

## Testing
- `ruff check .` *(fails: unused imports and other style issues)*
- `black --check .` *(fails: many files would be reformatted)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68421edb0970832fa9f32432a0bc955d