### PR TITLE
Build rows from agentic_doc chunks

### DIFF
--- a/tests/test_agentic_parse.py
+++ b/tests/test_agentic_parse.py
@@ -18,9 +18,9 @@ else:
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_agentic_parse_list(monkeypatch):
-    df = pd.DataFrame([{"Malzeme_Kodu": "A", "Açıklama": "Item", "Fiyat": 1.0}])
+    row = {"Malzeme_Kodu": "A", "Açıklama": "Item", "Fiyat": 1.0}
     parsed_doc = types.SimpleNamespace(
-        to_dataframe=lambda: df,
+        chunks=[types.SimpleNamespace(table_row=row)],
         page_summary=[{"page_number": 1, "rows": 1, "status": "success", "note": None}],
         token_counts={"input": 1, "output": 1},
     )
@@ -45,9 +45,9 @@ def test_agentic_parse_list(monkeypatch):
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_agentic_numeric_headers(monkeypatch):
-    df = pd.DataFrame([{0: "A1", 1: "Desc", 2: "5"}])
+    row = {0: "A1", 1: "Desc", 2: "5"}
     parsed_doc = types.SimpleNamespace(
-        to_dataframe=lambda: df,
+        chunks=[types.SimpleNamespace(table_row=row)],
         page_summary=[{"page_number": 1, "rows": 1, "status": "success"}],
         token_counts={"input": 1, "output": 1},
     )

--- a/tests/test_agentic_pdf.py
+++ b/tests/test_agentic_pdf.py
@@ -16,9 +16,9 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_agentic_pdf_columns(monkeypatch):
-    df_sample = pd.DataFrame([{"Malzeme_Kodu": "X1", "Açıklama": "Desc", "Fiyat": "5"}])
+    row = {"Malzeme_Kodu": "X1", "Açıklama": "Desc", "Fiyat": "5"}
     parsed_doc = types.SimpleNamespace(
-        to_dataframe=lambda: df_sample,
+        chunks=[types.SimpleNamespace(table_row=row)],
         page_summary=[{"page_number": 1, "rows": 1, "status": "success"}],
         token_counts={"input": 1, "output": 1},
     )


### PR DESCRIPTION
## Summary
- extract table rows directly from ParsedDocument chunks in `extract_from_pdf_agentic`
- adapt tests for new chunk-based behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684225a36be0832fa7b9e92dcfbc0081