### PR TITLE
Update ADE workflow without fallback

### DIFF
--- a/Price App/smart_price/core/extract_excel.py
+++ b/Price App/smart_price/core/extract_excel.py
@@ -92,6 +92,25 @@ POSSIBLE_MAIN_HEADERS = [_norm_header(h) for h in _RAW_MAIN_HEADERS]
 POSSIBLE_SUB_HEADERS = [_norm_header(h) for h in _RAW_SUB_HEADERS]
 
 
+def _map_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Rename common columns for code, description and price."""
+    norm = [_norm_header(c) for c in df.columns]
+
+    def pick(cands):
+        for h in cands:
+            if h in norm:
+                return df.columns[norm.index(h)]
+        return None
+
+    rename = {
+        pick(POSSIBLE_CODE_HEADERS): "Malzeme_Kodu",
+        pick(POSSIBLE_DESC_HEADERS): "Açıklama",
+        pick(POSSIBLE_PRICE_HEADERS): "Fiyat",
+    }
+    df.rename(columns={k: v for k, v in rename.items() if k}, inplace=True)
+    return df
+
+
 def find_columns_in_excel(
     df: pd.DataFrame,
 ) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:

--- a/Price App/smart_price/extract_excel.py
+++ b/Price App/smart_price/extract_excel.py
@@ -1,2 +1,8 @@
 """Wrapper module for convenience imports."""
+from smart_price.core import extract_excel as _core_excel
 from smart_price.core.extract_excel import *  # noqa: F401,F403
+
+_map_columns = _core_excel._map_columns
+
+__all__ = [n for n in globals() if not n.startswith("_")]
+__all__.append("_map_columns")

--- a/tests/test_agentic_parse.py
+++ b/tests/test_agentic_parse.py
@@ -18,9 +18,19 @@ else:
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_agentic_parse_list(monkeypatch):
-    row = {"Malzeme_Kodu": "A", "Açıklama": "Item", "Fiyat": 1.0}
+    header = ["Malzeme_Kodu", "Açıklama", "Fiyat"]
+    data = ["A", "Item", "1"]
     parsed_doc = types.SimpleNamespace(
-        chunks=[types.SimpleNamespace(table_row=row)],
+        chunks=[
+            types.SimpleNamespace(
+                chunk_type="table_row",
+                grounding=[types.SimpleNamespace(text=t) for t in header],
+            ),
+            types.SimpleNamespace(
+                chunk_type="table_row",
+                grounding=[types.SimpleNamespace(text=t) for t in data],
+            ),
+        ],
         page_summary=[{"page_number": 1, "rows": 1, "status": "success", "note": None}],
         token_counts={"input": 1, "output": 1},
     )
@@ -38,16 +48,27 @@ def test_agentic_parse_list(monkeypatch):
 
     df = mod.extract_from_pdf_agentic("dummy.pdf")
     assert len(df) == 1
-    assert df.to_dict("records") == [row]
+    parsed = df.to_dict("records")[0]
+    assert parsed == {"Malzeme_Kodu": "A", "Açıklama": "Item", "Fiyat": 1.0}
     assert getattr(df, "page_summary", None) == parsed_doc.page_summary
     assert getattr(df, "token_counts", None) == parsed_doc.token_counts
 
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_agentic_numeric_headers(monkeypatch):
-    row = {0: "A1", 1: "Desc", 2: "5"}
+    header = ["Malzeme Kodu", "Açıklama", "Fiyat"]
+    data = ["A1", "Desc", "5"]
     parsed_doc = types.SimpleNamespace(
-        chunks=[types.SimpleNamespace(table_row=row)],
+        chunks=[
+            types.SimpleNamespace(
+                chunk_type="table_row",
+                grounding=[types.SimpleNamespace(text=t) for t in header],
+            ),
+            types.SimpleNamespace(
+                chunk_type="table_row",
+                grounding=[types.SimpleNamespace(text=t) for t in data],
+            ),
+        ],
         page_summary=[{"page_number": 1, "rows": 1, "status": "success"}],
         token_counts={"input": 1, "output": 1},
     )

--- a/tests/test_agentic_pdf.py
+++ b/tests/test_agentic_pdf.py
@@ -16,9 +16,19 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_agentic_pdf_columns(monkeypatch):
-    row = {"Malzeme_Kodu": "X1", "Açıklama": "Desc", "Fiyat": "5"}
+    header = ["Malzeme_Kodu", "Açıklama", "Fiyat"]
+    data = ["X1", "Desc", "5"]
     parsed_doc = types.SimpleNamespace(
-        chunks=[types.SimpleNamespace(table_row=row)],
+        chunks=[
+            types.SimpleNamespace(
+                chunk_type="table_row",
+                grounding=[types.SimpleNamespace(text=t) for t in header],
+            ),
+            types.SimpleNamespace(
+                chunk_type="table_row",
+                grounding=[types.SimpleNamespace(text=t) for t in data],
+            ),
+        ],
         page_summary=[{"page_number": 1, "rows": 1, "status": "success"}],
         token_counts={"input": 1, "output": 1},
     )


### PR DESCRIPTION
## Summary
- add `_map_columns` in Excel parser and expose via wrapper
- rewrite AgenticDE PDF workflow to use new ADE chunk format and remove Vision fallback
- adjust Streamlit UI for explicit method selection and error handling
- rename extraction option to **LLM (Vision)**
- update unit tests for revised ADE parsing logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6842324055e8832f83cc0e5082b0af8d