### PR TITLE
Update agentic_doc parse usage

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -104,9 +104,7 @@ def extract_from_pdf_agentic(
         parse_path = tmp_file
 
     try:
-        docs = parse(parse_path, prompt=guide_prompt, cleanup_tmp_files=False)
-    except TypeError:  # pragma: no cover - older agentic_doc versions
-        docs = parse(parse_path, cleanup_tmp_files=False)
+        docs = parse(parse_path)
     except Exception as exc:
         logger.error("ADE failed: %s", exc, exc_info=True)
         raise


### PR DESCRIPTION
## Summary
- update `extract_pdf_agentic` to use new `agentic_doc.parse` API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842365606fc832f914c73e4dab79106