### PR TITLE
Update dependencies and fix Pandas 2.2 compatibility

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -6,6 +6,7 @@ import tempfile
 from typing import IO, Optional, Callable
 
 import pandas as pd
+import io
 
 try:
     from dotenv import load_dotenv, find_dotenv
@@ -121,7 +122,7 @@ def extract_from_pdf_agentic(
     def _ade_df(doc):
         return pd.concat(
             [
-                pd.read_html(ch.text)[0]
+                pd.read_html(io.StringIO(ch.text))[0]
                 for ch in doc.chunks
                 if ch.chunk_type in ("table", "text")
             ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,12 @@ dependencies = [
 where = ["Price App", "Sales App"]
 
 [project.optional-dependencies]
-agentic = ["agentic-doc>=0.2.3"]
+agentic = [
+    "agentic-doc>=0.2.3",
+    "lxml>=4.9",                # read_html için
+    "beautifulsoup4",
+    "html5lib",
+]
 
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- handle Pandas 2.2 read_html by wrapping text with `io.StringIO`
- import `io` in the agentic PDF parser
- extend optional dependencies for agentic parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68423e586df8832f9f03b981c32c050c