### PR TITLE
Add table_row support to agentic parser

### DIFF
--- a/tests/test_agentic_pdf.py
+++ b/tests/test_agentic_pdf.py
@@ -28,17 +28,22 @@ def test_agentic_pdf_columns(monkeypatch):
                 chunk_type="table_row",
                 grounding=[types.SimpleNamespace(text=t) for t in data],
             ),
+            types.SimpleNamespace(chunk_type="text", text="foo"),
         ],
         page_summary=[{"page_number": 1, "rows": 1, "status": "success"}],
         token_counts={"input": 1, "output": 1},
     )
     parse_mod = types.ModuleType("agentic_doc.parse")
     parse_mod.parse = lambda *_a, **_kw: [parsed_doc]
+    common_mod = types.ModuleType("agentic_doc.common")
+    common_mod.RetryableError = Exception
     agentic_pkg = types.ModuleType("agentic_doc")
     agentic_pkg.__path__ = []
     agentic_pkg.parse = parse_mod
+    agentic_pkg.common = common_mod
     monkeypatch.setitem(sys.modules, "agentic_doc", agentic_pkg)
     monkeypatch.setitem(sys.modules, "agentic_doc.parse", parse_mod)
+    monkeypatch.setitem(sys.modules, "agentic_doc.common", common_mod)
 
     mod = importlib.import_module("smart_price.core.extract_pdf_agentic")
     importlib.reload(mod)


### PR DESCRIPTION
## Summary
- handle `table_row` chunks in `_ade_df`
- ignore non-table chunks
- update agentic parser tests

## Testing
- `pytest tests/test_agentic_parse.py::test_agentic_parse_list -q`
- `pytest tests/test_agentic_parse.py::test_agentic_numeric_headers -q`
- `pytest tests/test_agentic_pdf.py::test_agentic_pdf_columns -q`
- `pytest -q` *(fails: AttributeError/KeyError in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_b_684240f1e4e4832fbddb0232639e125b