### PR TITLE
Forward prompts to agentic-doc

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -105,7 +105,10 @@ def extract_from_pdf_agentic(
         parse_path = tmp_file
 
     try:
-        docs = parse(parse_path)   # Agentic-doc 0.2.3
+        if guide_prompt is not None:
+            docs = parse(parse_path, prompt=guide_prompt)  # Agentic-doc 0.2.3+
+        else:
+            docs = parse(parse_path)   # Agentic-doc 0.2.3
     except Exception as exc:
         logger.error("ADE failed: %s", exc, exc_info=True)
         raise

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ These values configure the internal `agentic_doc` Settings object.  The
 optimal numbers depend on your API rate limit and document size.
 
 ``agentic_doc.parse`` now returns a list of ``ParsedDocument`` objects. The
-tools use the first item in that list.
+tools use the first item in that list. When an extraction guide provides
+page prompts for a PDF file these prompts are forwarded to
+``agentic_doc.parse``.
 
 ### Building a Windows executable
 


### PR DESCRIPTION
## Summary
- pass extraction guide prompts to `agentic_doc.parse`
- document prompt forwarding in README
- test that prompts are forwarded to the parse function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6844194863c8832fab9bf21b89f56f8e