### PR TITLE
Add ADE chunk debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ When the AgenticDE workflow is used, the log also notes the type of object
 returned by ``agentic_doc.parse`` and dumps any ``page_summary`` entries. If no
 rows are produced a warning records how many pages were processed. All these
 messages include the source PDF name.
+Set ``ADE_DEBUG=1`` to save each ``agentic_doc`` chunk under ``LLM_Output_db/<PDF name>``
+and log its type and text. This is useful to inspect how table rows were
+interpreted when header detection fails.
 Errors raised by ``agentic_doc`` now log the HTTP status code, full response
 text and exception details to help diagnose rate limit, authentication or
 parsing issues.


### PR DESCRIPTION
## Summary
- add ADE_DEBUG-controlled chunk debug output in `extract_pdf_agentic`
- document chunk logging in README
- test debug output generation

## Testing
- `pytest tests/test_agentic_parse.py::test_agentic_debug_output -q`

------
https://chatgpt.com/codex/tasks/task_b_68441e6307c0832f91720a2e18aff0de