### PR TITLE
Add default prompt to agentic parse

### DIFF
--- a/Price App/smart_price/core/extract_pdf_agentic.py
+++ b/Price App/smart_price/core/extract_pdf_agentic.py
@@ -33,6 +33,7 @@ from smart_price.core.extract_excel import (
 )
 from .common_utils import normalize_price, detect_currency, normalize_currency
 from .debug_utils import save_debug, set_output_subdir
+from smart_price.core.ocr_llm_fallback import DEFAULT_PROMPT
 
 try:
     from agentic_doc.common import RetryableError as AgenticDocError
@@ -119,7 +120,7 @@ def extract_from_pdf_agentic(
         if guide_prompt is not None:
             docs = parse(parse_path, prompt=guide_prompt)  # Agentic-doc 0.2.3+
         else:
-            docs = parse(parse_path)   # Agentic-doc 0.2.3
+            docs = parse(parse_path, prompt=DEFAULT_PROMPT)   # Agentic-doc 0.2.3
     except Exception as exc:
         logger.error("ADE failed: %s", exc, exc_info=True)
         raise


### PR DESCRIPTION
## Summary
- always provide a prompt to `agentic_doc.parse`
- test that the default prompt is sent when no guide prompt exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684421214dc8832fa88b93868dc45e5e