### PR TITLE
Fix POPPLERDIR spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ configuration folder.  The resulting binary will appear in the `dist` folder.
 Both Poppler and Tesseract binaries are bundled from the `poppler/bin` folder
 so the resulting EXE runs without additional dependencies. Place the actual
 `pdftoppm.exe`, `pdftocairo.exe` and `pdfinfo.exe` files there first.  If you
-store these tools elsewhere edit `POPLPLERDIR` (and set `TESSERACT_CMD` if needed) in
+store these tools elsewhere edit `POPPLERDIR` (and set `TESSERACT_CMD` if needed) in
 `build_windows_exe.bat` to point to the correct paths.  The batch file
 collects all Streamlit resources so the executable launches without a
 `PackageNotFoundError` for the `streamlit` distribution. The launcher script

--- a/build_windows_exe.bat
+++ b/build_windows_exe.bat
@@ -9,14 +9,14 @@ set LOGOFOLDER=logo
 set PRICEAPP=Price App
 set STREAMLITCFG=.streamlit
 REM Poppler utilities (pdftoppm.exe, pdftocairo.exe, pdfinfo.exe)
-set POPLPLERDIR=poppler\bin
+set POPPLERDIR=poppler\bin
 
 pyinstaller --noconfirm --onefile ^
     --add-data "%DATAFOLDER%;%DATAFOLDER%" ^
     --add-data "%LOGOFOLDER%;logo" ^
     --add-data "%PRICEAPP%;Price App" ^
     --add-data "%STREAMLITCFG%;.streamlit" ^
-    --add-binary "%POPLPLERDIR%\*;poppler\bin" ^
+    --add-binary "%POPPLERDIR%\*;poppler\bin" ^
     --hidden-import "streamlit.web.cli" --collect-all streamlit "%SCRIPT%"
 
 ECHO Build complete. Look in the dist folder for the EXE.


### PR DESCRIPTION
## Summary
- fix spelling of `POPPLERDIR` in batch file
- update README to match

## Testing
- `ruff check .` *(fails: found style violations)*
- `black --check .` *(fails: would reformat files)*
- `pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684483e448ec832f96448cd07e059455