### PR TITLE
Fix run_sales_app launcher

### DIFF
--- a/run_sales_app.py
+++ b/run_sales_app.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 import sys
 from streamlit.web import cli as stcli
@@ -7,4 +6,5 @@ if __name__ == "__main__":
     pkg_root = pathlib.Path(__file__).parent
     sys.path.insert(0, str(pkg_root / "Sales App"))
     st_file = pkg_root / "Sales App" / "sales_app" / "streamlit_app.py"
-    stcli.main(["streamlit", "run", str(st_file)])
+    sys.argv = ["streamlit", "run", str(st_file)]
+    stcli.main()


### PR DESCRIPTION
## Summary
- clean up `run_sales_app.py`
- follow same launch logic as `run_app.py`

## Testing
- `python run_sales_app.py`
- `pytest -q` *(fails: ModuleNotFoundError, various test failures)*

------
https://chatgpt.com/codex/tasks/task_b_6844e27d4e50832f9bf780cd15f837d4