### PR TITLE
Fix master dataset URL

### DIFF
--- a/Price App/smart_price/config.py
+++ b/Price App/smart_price/config.py
@@ -35,7 +35,8 @@ _DEFAULT_POPPLER_PATH = Path(__file__).resolve().parents[2] / "poppler" / "bin"
 
 # Default remote repository for the public demo data
 _DEFAULT_BASE_REPO_URL = (
-    "https://raw.githubusercontent.com/USERNAME/Smart_Price/master"
+    "https://raw.githubusercontent.com/muratturan19/Smart_Price/main/"
+    "Master_data_base"
 )
 
 # Overlay defaults

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,7 +49,7 @@ def test_defaults(monkeypatch):
     assert cfg.OUTPUT_DB == root / "output" / "fiyat_listesi.db"
     assert cfg.OUTPUT_LOG == root / "output" / "source_log.csv"
     assert cfg.LOG_PATH == root / "smart_price.log"
-    assert cfg.BASE_REPO_URL.endswith("Smart_Price/master")
+    assert cfg.BASE_REPO_URL.endswith("Smart_Price/main/Master_data_base")
     assert cfg.DEFAULT_DB_URL == f"{cfg.BASE_REPO_URL}/master.db"
     assert cfg.DEFAULT_IMAGE_BASE_URL == cfg.BASE_REPO_URL
     assert cfg.EXTRACTION_GUIDE_PATH == root / "extraction_guide.csv"


### PR DESCRIPTION
## Summary
- point default repo to valid GitHub URL
- fix tests for new path

## Testing
- `pytest -q` *(fails: 24 failed, 53 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_68470232334c832fa0c417e34be8adc3