### PR TITLE
Fix Windows temp file issue in Streamlit sales app

### DIFF
--- a/Sales App/sales_app/streamlit_app.py
+++ b/Sales App/sales_app/streamlit_app.py
@@ -37,12 +37,18 @@ def _load_dataset(url: str) -> pd.DataFrame:
     logger.info("Fetching master data from %s", url)
     resp = requests.get(url)
     resp.raise_for_status()
-    with tempfile.NamedTemporaryFile(suffix=".db") as tmp:
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+    try:
         tmp.write(resp.content)
-        tmp.flush()
+        tmp.close()
         conn = sqlite3.connect(tmp.name)
         df = pd.read_sql("SELECT * FROM prices", conn)
         conn.close()
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
     return df
 
 


### PR DESCRIPTION
## Summary
- use a NamedTemporaryFile that can be reopened on Windows
- clean up the temporary file after reading the database

## Testing
- `ruff check .` *(fails: Found 31 errors)*
- `black --check .` *(fails: 30 files would be reformatted)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68470a83f058832f9701ae6df1b73ab7