### PR TITLE
Fix SalesApp column mismatch

### DIFF
--- a/Sales App/sales_app/streamlit_app.py
+++ b/Sales App/sales_app/streamlit_app.py
@@ -49,6 +49,24 @@ def _load_dataset(url: str) -> pd.DataFrame:
             os.unlink(tmp.name)
         except OSError:
             pass
+    column_map = {
+        "material_code": "Malzeme_Kodu",
+        "description": "Açıklama",
+        "price": "Fiyat",
+        "unit": "Birim",
+        "box_count": "Kutu_Adedi",
+        "price_currency": "Para_Birimi",
+        "source_file": "Kaynak_Dosya",
+        "source_page": "Sayfa",
+        "image_path": "Image_Path",
+        "record_code": "Record_Code",
+        "year": "Yil",
+        "brand": "Marka",
+        "main_header": "Ana_Baslik",
+        "sub_header": "Alt_Baslik",
+        "category": "Kategori",
+    }
+    df.rename(columns=column_map, inplace=True)
     return df
 
 

--- a/tests/test_sales_app.py
+++ b/tests/test_sales_app.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import sqlite3
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+st_stub = sys.modules.get('streamlit', types.ModuleType('streamlit'))
+if not hasattr(st_stub, 'cache_data'):
+    st_stub.cache_data = lambda *a, **k: (lambda f: f)
+sys.modules['streamlit'] = st_stub
+from sales_app import streamlit_app
+
+
+def test_load_dataset_renames(tmp_path, monkeypatch):
+    db_file = tmp_path / "data.db"
+    df = pd.DataFrame({"material_code": ["X1"], "description": ["Item"]})
+    with sqlite3.connect(db_file) as conn:
+        df.to_sql("prices", conn, index=False)
+
+    content = db_file.read_bytes()
+
+    class FakeResp:
+        def __init__(self, data):
+            self.content = data
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(streamlit_app.requests, "get", lambda _u: FakeResp(content))
+
+    result = streamlit_app._load_dataset("http://example.com/db")
+    assert "Malzeme_Kodu" in result.columns
+    assert "Açıklama" in result.columns


### PR DESCRIPTION
## Summary
- convert DB column names to Turkish in sales app loader
- add regression test for dataset column translation

## Testing
- `pytest tests/test_sales_app.py -q`
- `pytest -q` *(fails: KeyError 'Para_Birimi' and others)*

------
https://chatgpt.com/codex/tasks/task_b_68470c83a958832f8a51e92348cf8b90