### PR TITLE
Fix master data base directory

### DIFF
--- a/Price App/smart_price/config.py
+++ b/Price App/smart_price/config.py
@@ -17,8 +17,8 @@ except Exception:  # pragma: no cover - optional dependency
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Default locations matching the repository layout
-_DEFAULT_MASTER_DB_PATH = _REPO_ROOT / "Master data base" / "master.db"
-_DEFAULT_MASTER_EXCEL_PATH = _REPO_ROOT / "Master data base" / "master_dataset.xlsx"
+_DEFAULT_MASTER_DB_PATH = _REPO_ROOT / "Master_data_base" / "master.db"
+_DEFAULT_MASTER_EXCEL_PATH = _REPO_ROOT / "Master_data_base" / "master_dataset.xlsx"
 _DEFAULT_IMAGE_DIR = _REPO_ROOT / "images"
 _DEFAULT_SALES_APP_DIR = _REPO_ROOT / "Sales App" / "sales_app"
 _DEFAULT_PRICE_APP_DIR = _REPO_ROOT / "Price App" / "smart_price"

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -537,7 +537,7 @@ def save_master_dataset(
 
     upload_ok = upload_folder(
         Path(config.MASTER_EXCEL_PATH).parent,
-        remote_prefix="Master data base",
+        remote_prefix="Master_data_base",
     )
 
     if upload_ok:
@@ -566,7 +566,7 @@ def reset_database() -> None:
             pass
 
     delete_github_folder("LLM_Output_db")
-    delete_github_folder("Master data base")
+    delete_github_folder("Master_data_base")
 
 
 def upload_page():

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ records are saved.
 
 From the interface you can upload Excel/PDF price lists and search the
 resulting master dataset. When you save the merged data it writes both
-`Master data base/master_dataset.xlsx` and `Master data base/master.db`
+`Master_data_base/master_dataset.xlsx` and `Master_data_base/master.db`
 relative to the directory from which you launch the app. The success
 message shows the full paths of these files and notes whether a GitHub
 upload was attempted.
@@ -207,7 +207,7 @@ The log records extra details to help trace each step:
 - per-page debug files stored under `LLM_Output_db/<PDF adı>` (set
   `SMART_PRICE_DEBUG_DIR` to override the location)
  - set `GITHUB_REPO` and `GITHUB_TOKEN` to automatically push each debug
-   directory and the files under `Master data base/` (including
+   directory and the files under `Master_data_base/` (including
    `master_dataset.xlsx` and `master.db`) to the configured repository
    under their respective folders (optionally specify `GITHUB_BRANCH`).
    If these variables are not set the upload is skipped gracefully.
@@ -216,7 +216,7 @@ The log records extra details to help trace each step:
 
 Use the **Database Sıfırla** page in the Streamlit interface to remove all
 local output and master files.  When GitHub credentials are configured the same
-folders (`LLM_Output_db` and `Master data base`) are cleared from the
+folders (`LLM_Output_db` and `Master_data_base`) are cleared from the
 repository as well.
 
 ### Linting and tests

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,8 +38,8 @@ def test_defaults(monkeypatch):
         monkeypatch.delenv(name, raising=False)
     importlib.reload(cfg)
     root = Path(__file__).resolve().parent.parent
-    assert cfg.MASTER_EXCEL_PATH == root / "Master data base" / "master_dataset.xlsx"
-    assert cfg.MASTER_DB_PATH == root / "Master data base" / "master.db"
+    assert cfg.MASTER_EXCEL_PATH == root / "Master_data_base" / "master_dataset.xlsx"
+    assert cfg.MASTER_DB_PATH == root / "Master_data_base" / "master.db"
     assert cfg.IMAGE_DIR == root / "images"
     assert cfg.SALES_APP_DIR == root / "Sales App" / "sales_app"
     assert cfg.PRICE_APP_DIR == root / "Price App" / "smart_price"


### PR DESCRIPTION
## Summary
- point default master database paths to `Master_data_base`
- upload to `Master_data_base` folder in the Streamlit price app
- adjust tests and docs to match new folder name

## Testing
- `ruff check .` *(fails: 32 errors)*
- `pytest -q` *(fails: 10 failed, 54 passed, 15 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_684740e3cb1c832f9642e0c785f0611c