### PR TITLE
Add prompt selection logging

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -235,6 +235,10 @@ def parse(
                 image_bytes = f.read()
             img_base64 = base64.b64encode(image_bytes).decode()
             prompt_text = _get_prompt(idx)
+            logger.debug(
+                "Prompt being used for extraction (truncated): %s",
+                prompt_text[:200],
+            )
             total_input_tokens += num_tokens_from_messages(
                 [{"role": "user", "content": prompt_text}], model_name
             )


### PR DESCRIPTION
## Summary
- log which extraction guide entry was matched
- show truncated prompt text in fallback LLM
- handle older `parse` signatures and missing columns

## Testing
- `python -m pytest tests/test_price_parser.py::test_extract_from_pdf_llm_sets_page_added -q`
- `python -m pytest -q` *(fails: `test_grounding_fallback`, `test_big_alert_default_icon`, `test_extract_from_pdf_default_currency`, `test_extract_from_pdf_table_headers`, `test_extract_from_pdf_bytesio`, `test_llm_debug_files`)*

------
https://chatgpt.com/codex/tasks/task_b_68480ace8980832fa8be7cfbbf5b6d45