### PR TITLE
Fix markdown prompt parsing

### DIFF
--- a/Price App/smart_price/core/prompt_utils.py
+++ b/Price App/smart_price/core/prompt_utils.py
@@ -44,11 +44,13 @@ def _parse_md_guide(path: Path) -> List[Dict[str, Any]]:
                 continue
             if in_code:
                 continue
+            if lstripped.startswith("###") or "JSON" in lstripped.upper():
+                break
             if lstripped.startswith("#"):
                 continue
-            if "JSON" in lstripped.upper():
-                break
-            cleaned.append(ln)
+            if lstripped.startswith(('-', '*')):
+                lstripped = lstripped.lstrip('-*').strip()
+            cleaned.append(lstripped)
         body = "\n".join(cleaned).strip()
         result.append({"pdf": title, "page": None, "prompt": body})
 

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -55,3 +55,15 @@ def test_prompts_for_pdf_no_match(tmp_path):
     path = tmp_path / "guide.csv"
     path.write_text("pdf,page,prompt\nother.pdf,1,HELLO\n")
     assert prompt_utils.prompts_for_pdf("dummy.pdf", str(path)) is None
+
+
+def test_parse_md_guide_stops_at_json(tmp_path):
+    path = tmp_path / "guide.md"
+    path.write_text(
+        "# G\n\n## BRAND\n- Inst1\n### Çıktı Formatı\n```json\n{\n  \"foo\": \"bar\"\n}\n```"
+    )
+    data = prompt_utils.load_extraction_guide(str(path))
+    assert len(data) == 1
+    prompt = data[0]["prompt"]
+    assert "foo" not in prompt and "bar" not in prompt
+


### PR DESCRIPTION
## Summary
- improve `_parse_md_guide` to stop at JSON sections and trim bullets
- add regression test ensuring JSON examples aren't returned

## Testing
- `pytest tests/test_prompt_utils.py::test_parse_md_guide_stops_at_json -q`


------
https://chatgpt.com/codex/tasks/task_b_68497ac251c4832f93c79212893ecd98