### PR TITLE
Add short prompt retry

### DIFF
--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -4,6 +4,7 @@ import sys
 import types
 import time
 import threading
+import logging
 
 # Provide minimal stubs for optional deps before importing project code
 if 'PIL' not in sys.modules:
@@ -136,3 +137,55 @@ def test_parse_parallel_execution(monkeypatch):
         del sys.modules['pandas']
 
     assert max(concurrency) > 1
+
+
+def test_retry_short_prompt(monkeypatch, caplog):
+    def fake_convert(_path, **_kwargs):
+        return [FakeImage()]
+
+    pdf2image_stub = types.SimpleNamespace(convert_from_path=fake_convert)
+    monkeypatch.setitem(sys.modules, "pdf2image", pdf2image_stub)
+
+    calls = []
+
+    def create(**kwargs):
+        text = kwargs["messages"][0]["content"][0]["text"]
+        calls.append(text)
+        if len(calls) == 1:
+            content = "invalid"
+        else:
+            content = "[]"
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+        )
+
+    chat_stub = types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    openai_stub = types.SimpleNamespace(chat=chat_stub)
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    _pandas_stubbed = False
+    try:
+        import pandas as pd  # noqa: F401
+    except ModuleNotFoundError:
+        pd = types.ModuleType("pandas")
+        sys.modules["pandas"] = pd
+        _pandas_stubbed = True
+    if not hasattr(pd, "DataFrame"):
+        pd.DataFrame = lambda *args, **kwargs: args[0]
+        _pandas_stubbed = True
+
+    import importlib
+    import smart_price.core.ocr_llm_fallback as mod
+    importlib.reload(mod)
+
+    with caplog.at_level(logging.INFO, logger="smart_price"):
+        mod.parse("dummy.pdf")
+
+    if _pandas_stubbed:
+        del sys.modules["pandas"]
+
+    assert len(calls) == 2
+    assert calls[1] == mod.SHORT_PROMPT
+    messages = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Retrying page 1 with short prompt" in messages


### PR DESCRIPTION
## Summary
- fall back to a shorter prompt when JSON parsing fails in `ocr_llm_fallback.parse`
- test retry logic in `test_ocr_llm_fallback`

## Testing
- `pytest tests/test_ocr_llm_fallback.py -q`
- `pytest -q` *(fails: FileNotFoundError, AttributeError, and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_6849902285d8832fa4db2a2af95f63bf