### PR TITLE
Add dataframe validation and cleanup

### DIFF
--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -33,6 +33,7 @@ from .common_utils import (
     detect_brand,
     gpt_clean_text,
     safe_json_parse,
+    validate_output_df,
 )
 import time
 from . import ocr_llm_fallback
@@ -206,7 +207,7 @@ def extract_from_pdf(
         notify(f"Phase 1 parsed {len(df)} rows")
         if len(df) >= MIN_ROWS_PARSER:
             notify(f"Finished {src} via pdfplumber with {len(df)} rows")
-            return df
+            return validate_output_df(df)
         phase1_df = df
 
     def _llm_extract_from_image(text: str) -> list[dict]:
@@ -420,7 +421,7 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
             notify("Debug klasörü yüklendi")
         else:
             notify("GitHub upload başarısız", "warning")
-        return result
+        return validate_output_df(result)
 
     if "Para_Birimi" not in result.columns:
         result["Para_Birimi"] = None
@@ -500,4 +501,4 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
         notify("Debug klasörü yüklendi")
     else:
         notify("GitHub upload başarısız", "warning")
-    return result_df
+    return validate_output_df(result_df)

--- a/tests/test_validate_df.py
+++ b/tests/test_validate_df.py
@@ -1,0 +1,21 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pandas as pd
+from smart_price.core.common_utils import validate_output_df, EXTRACTION_FIELDS
+
+
+def test_validate_adds_columns_and_normalizes():
+    df = pd.DataFrame({"Açıklama": ["Item"], "Fiyat": ["1.000,50"]})
+    result = validate_output_df(df)
+    assert result.columns.tolist() == EXTRACTION_FIELDS
+    assert result.iloc[0]["Fiyat"] == 1000.50
+    assert result.iloc[0]["Para_Birimi"] == "₺"
+
+
+def test_validate_normalizes_currency():
+    df = pd.DataFrame({"Açıklama": ["A"], "Fiyat": ["10"], "Para_Birimi": ["usd"]})
+    result = validate_output_df(df)
+    assert result.iloc[0]["Para_Birimi"] == "$"
+


### PR DESCRIPTION
## Summary
- validate extracted DataFrame columns and normalize values
- use the new validation in `extract_from_pdf`
- test validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849ba310e60832f9e88925869b5679b