### PR TITLE
Run LLM extraction for all PDFs

### DIFF
--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -205,9 +205,6 @@ def extract_from_pdf(
         ]
         df = df.reindex(columns=cols, fill_value=None)
         notify(f"Phase 1 parsed {len(df)} rows")
-        if len(df) >= MIN_ROWS_PARSER:
-            notify(f"Finished {src} via pdfplumber with {len(df)} rows")
-            return validate_output_df(df)
         phase1_df = df
 
     def _llm_extract_from_image(text: str) -> list[dict]:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ replace the placeholders before running the tools.
 Download Poppler for Windows (64-bit) and copy `pdftoppm.exe`,
 `pdftocairo.exe` and `pdfinfo.exe` into `poppler/bin`.
 
-PDF files are parsed entirely through GPT‑4o Vision. Each page image is generated with **pdf2image** and sent to the model with a Turkish prompt. The response contains structured JSON for the rows.
+PDF files are first scanned using **pdfplumber** to catch any obvious table rows.  The GPT‑4o Vision pipeline then runs for every file. Each page image is generated with **pdf2image** and sent to the model with a Turkish prompt.  If the model returns rows these replace the `pdfplumber` result; otherwise the parsed text from `pdfplumber` is used as a fallback.
 
 ### LLM assistance
 


### PR DESCRIPTION
## Summary
- always run `ocr_llm_fallback.parse` in `extract_from_pdf`
- update tests to expect the LLM pipeline
- clarify PDF processing in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849d4f575e8832f9444220ca9ae4afe