### PR TITLE
Remove pdfplumber dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "pandas",
-    "pdfplumber",
     "streamlit",
     "openpyxl",
     "xlrd",


### PR DESCRIPTION
## Summary
- remove `pdfplumber` from required dependencies

## Testing
- `pytest -q` *(fails: Module 'pandas' has no attribute 'DataFrame')*

------
https://chatgpt.com/codex/tasks/task_b_6849e5466744832fb712741d58aa84eb