### PR TITLE
Update default OCR prompt and adjust tests

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -51,12 +51,71 @@ if TYPE_CHECKING:  # pragma: no cover - type hints only
 
 logger = logging.getLogger("smart_price")
 
-DEFAULT_PROMPT = (
-    "PDF'deki ürün satırlarını JSON dizi olarak çıkart. "
-    "Her öğe Malzeme_Kodu, Açıklama, Fiyat, Para_Birimi, "
-    "Ana_Baslik, Alt_Baslik, Kaynak_Dosya ve Sayfa alanlarını içersin. "
-    "Para birimi yoksa TL yaz."
-)
+DEFAULT_PROMPT = """
+Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün tablosu/ürün satırlarını ve bunların üst başlıklarını tam olarak, eksiksiz ve yapısal şekilde çıkarmaktır.
+
+**Çalışma Akışın:**
+
+1. **Her PDF için, özel extraction talimatları olup olmadığını kontrol etmelisin:**
+    - Sistemde “extraction_guide” adında bir referans dosyası olabilir.
+    - Eğer bu dosya mevcutsa ve işlediğin PDF’ye (veya sayfa/alanına) ait özel bir extraction promptu/talimatı varsa, önce bu talimata uygun şekilde çıkarım yap.
+    - Eğer dosyada talimat bulunamazsa veya extraction_guide dosyası hiç yoksa, aşağıdaki _Genel Extraction Talimatları_ ile devam et.
+
+2. **Dosya veya talimat yoksa, hata verme; genel kurallarla standart extraction yap.**
+
+---
+
+### **Genel Extraction Talimatları:**
+
+- Her ürün satırının;
+    - Hangi ana başlık altında olduğunu (“Ana_Baslik”)
+    - Hangi alt başlık altında olduğunu (“Alt_Baslik” – varsa)
+    - Ürün kodu, fiyatı, açıklaması/özellikleri, varsa adet, birim, para birimi, kutu adedi, marka gibi tüm alanlarını
+    - PDF dosya adı (“Kaynak_Dosya”) ve sayfa numarasını (“Sayfa”)
+    açık şekilde ayrıştır.
+
+- Tablo başlıklarını, alt başlıkları, genel açıklamaları **veri satırı olarak alma**;
+  sadece gerçek ürün satırlarını çıkart.
+
+- Çıktı formatın JSON dizi olacak.
+  Her veri satırı için:
+    - Ana_Baslik (zorunlu)
+    - Alt_Baslik (varsa, zorunlu değil)
+    - Malzeme_Kodu (zorunlu)
+    - Açıklama/Özellikler (varsa)
+    - Fiyat (zorunlu)
+    - Para_Birimi (yoksa “TL” yaz)
+    - Kaynak_Dosya
+    - Sayfa
+    - (Varsa ek alanlar: Adet, Birim, Marka, Kutu_Adedi...)
+
+Çıktıdaki kolon adları tam olarak: Malzeme_Kodu, Açıklama, Fiyat, Para_Birimi, Ana_Baslik, Alt_Baslik, Sayfa. İlk satıra başlık yazmayın.
+
+---
+
+### **Extraction_guide Kullanımı:**
+- extraction_guide adlı dosya varsa, PDF başlığına veya dosya adına uygun talimatı uygula.
+- Bulamazsan veya extraction_guide yoksa, bu prompttaki _Genel Extraction Talimatları_ ile çalış.
+
+---
+
+### **Çıktı Örneği:**
+
+```
+[
+  {
+    "Ana_Baslik": "IE3 ALÜMİNYUM GÖVDELİ IEC 3~FAZLI ASENKRON ELEKTRİK MOTORLARI",
+    "Alt_Baslik": "2k-3000 d/dak",
+    "Malzeme_Kodu": "3MAS 80MA2",
+    "Açıklama": "0.55 KW",
+    "Fiyat": "110,00",
+    "Para_Birimi": "USD",
+    "Kaynak_Dosya": "Omega Motor Fiyat Listesi 2025.pdf",
+    "Sayfa": "14"
+  }
+]
+```
+"""
 
 
 def _range_bounds(pages: Sequence[int] | range | None) -> tuple[int | None, int | None]:

--- a/tests/test_sales_app.py
+++ b/tests/test_sales_app.py
@@ -3,13 +3,45 @@ import sys
 import sqlite3
 import types
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, root_dir)
+sys.path.insert(0, os.path.join(root_dir, "Price App"))
+sys.path.insert(0, os.path.join(root_dir, "Sales App"))
 
-import pandas as pd
+_pandas_stubbed = False
+try:  # pragma: no cover - pandas may not be installed
+    import pandas as pd  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - fallback to stub
+    pd = types.ModuleType('pandas')
+    sys.modules['pandas'] = pd
+    _pandas_stubbed = True
+if not hasattr(pd, 'DataFrame'):
+    class FakeDF(dict):
+        def __init__(self, data=None):
+            super().__init__(data or {})
+            self.columns = list(self.keys())
+        def to_sql(self, name, conn, index=False):
+            pass
+        def rename(self, columns=None, inplace=False):
+            if columns:
+                for old, new in columns.items():
+                    if old in self:
+                        self[new] = self.pop(old)
+                self.columns = list(self.keys())
+            if not inplace:
+                return self
+    def _read_sql(query, conn):
+        return FakeDF({'material_code': ['X1'], 'description': ['Item']})
+    pd.DataFrame = FakeDF
+    pd.read_sql = _read_sql
 st_stub = sys.modules.get('streamlit', types.ModuleType('streamlit'))
 if not hasattr(st_stub, 'cache_data'):
     st_stub.cache_data = lambda *a, **k: (lambda f: f)
 sys.modules['streamlit'] = st_stub
+if 'requests' not in sys.modules:
+    req_stub = types.ModuleType('requests')
+    req_stub.get = lambda *_a, **_k: None
+    sys.modules['requests'] = req_stub
 from sales_app import streamlit_app
 
 


### PR DESCRIPTION
## Summary
- expand OCR fallback prompt for detailed extraction instructions
- add missing pandas and requests stubs in `test_sales_app`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684a2c64fdac832fab8bbd82c07bddd4