### PR TITLE
Update default LLM prompt

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -56,12 +56,8 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
 
 **Çalışma Akışın:**
 
-1. **Her PDF için, özel extraction talimatları olup olmadığını kontrol etmelisin:**
-    - Sistemde “extraction_guide” adında bir referans dosyası olabilir.
-    - Eğer bu dosya mevcutsa ve işlediğin PDF’ye (veya sayfa/alanına) ait özel bir extraction promptu/talimatı varsa, önce bu talimata uygun şekilde çıkarım yap.
-    - Eğer dosyada talimat bulunamazsa veya extraction_guide dosyası hiç yoksa, aşağıdaki _Genel Extraction Talimatları_ ile devam et.
-
-2. **Dosya veya talimat yoksa, hata verme; genel kurallarla standart extraction yap.**
+1. Bu PDF için extraction_guide içinde tanımlı bir talimat varsa önce bu talimata uygun şekilde çıkarım yap. Talimat yoksa aşağıdaki _Genel Extraction Talimatları_ ile devam et.
+2. Talimat bulunamazsa hata verme; genel kurallarla standart extraction yap.
 
 ---
 
@@ -94,8 +90,8 @@ Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün ta
 ---
 
 ### **Extraction_guide Kullanımı:**
-- extraction_guide adlı dosya varsa, PDF başlığına veya dosya adına uygun talimatı uygula.
-- Bulamazsan veya extraction_guide yoksa, bu prompttaki _Genel Extraction Talimatları_ ile çalış.
+- extraction_guide dosyasında bu PDF'e özel bir talimat tanımlıysa otomatik olarak uygulanır.
+- Talimat yoksa bu prompttaki _Genel Extraction Talimatları_ geçerlidir.
 
 ---
 


### PR DESCRIPTION
## Summary
- reflect new extraction guide workflow in ocr_llm_fallback prompt

## Testing
- `ruff check .` *(fails: found 33 errors)*
- `pytest -q` *(fails: 15 failed, 70 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_684a2f78953c832f9626831e4880a5c5