### PR TITLE
Prefix raw header hint in prompts

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -36,7 +36,7 @@ from .common_utils import (
     safe_json_parse,
     log_metric,
 )
-from .prompt_utils import prompts_for_pdf
+from .prompt_utils import prompts_for_pdf, RAW_HEADER_HINT
 from .debug_utils import save_debug, save_debug_image, set_output_subdir
 from .token_utils import (
     num_tokens_from_messages,
@@ -203,9 +203,10 @@ def parse(
     model_name = os.getenv("OPENAI_MODEL", "gpt-4o")
 
     def _get_prompt(page: int) -> str:
+        fallback = RAW_HEADER_HINT + "\n" + DEFAULT_PROMPT
         if isinstance(prompt, dict):
-            return prompt.get(page, prompt.get(0, DEFAULT_PROMPT))
-        return prompt if prompt is not None else DEFAULT_PROMPT
+            return prompt.get(page, prompt.get(0, fallback))
+        return prompt if prompt is not None else fallback
 
     rows: list[dict[str, object]] = []
     page_summary: list[dict[str, object]] = []

--- a/Price App/smart_price/core/prompt_utils.py
+++ b/Price App/smart_price/core/prompt_utils.py
@@ -8,6 +8,34 @@ import logging
 
 from smart_price import config
 from .common_utils import detect_brand
+from .extract_excel import (
+    _RAW_CODE_HEADERS,
+    _RAW_DESC_HEADERS,
+    _RAW_SHORT_HEADERS,
+    _RAW_PRICE_HEADERS,
+    _RAW_CURRENCY_HEADERS,
+    _RAW_MAIN_HEADERS,
+    _RAW_SUB_HEADERS,
+)
+
+# Concise hint listing all possible raw column headers that may appear in Excel
+# or PDF tables. This is added to LLM prompts so it knows which column labels to
+# look out for when parsing tabular data.
+RAW_HEADER_HINT = (
+    "Olası kolon başlıkları; kodlar: "
+    + ", ".join(_RAW_CODE_HEADERS + _RAW_SHORT_HEADERS)
+    + "; açıklamalar: "
+    + ", ".join(_RAW_DESC_HEADERS)
+    + "; fiyatlar: "
+    + ", ".join(_RAW_PRICE_HEADERS)
+    + "; para birimleri: "
+    + ", ".join(_RAW_CURRENCY_HEADERS)
+    + "; ana başlıklar: "
+    + ", ".join(_RAW_MAIN_HEADERS)
+    + "; alt başlıklar: "
+    + ", ".join(_RAW_SUB_HEADERS)
+    + "."
+)
 
 logger = logging.getLogger("smart_price")
 
@@ -133,10 +161,10 @@ def prompts_for_pdf(pdf_name: str, path: str | None = None) -> Dict[int, str] | 
         if matched_name is None:
             matched_name = Path(str(file_field)).stem
         if page_val in (None, "", "null"):
-            mapping[0] = prompt
+            mapping[0] = RAW_HEADER_HINT + "\n" + prompt
         else:
             try:
-                mapping[int(page_val)] = prompt
+                mapping[int(page_val)] = RAW_HEADER_HINT + "\n" + prompt
             except (ValueError, TypeError):
                 continue
     if mapping:

--- a/tests/test_prompt_guide.py
+++ b/tests/test_prompt_guide.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from smart_price import config
 import smart_price.core.extract_pdf as pdf_mod
+from smart_price.core import prompt_utils
 
 
 class DummyResult:
@@ -34,7 +35,7 @@ def _run_extract(tmp_path, guide_content, filename="dummy.pdf"):
 
 def test_guide_hit(monkeypatch, tmp_path):
     prompt = _run_extract(tmp_path, "pdf,page,prompt\ndummy.pdf,1,HELLO\n")
-    assert prompt == {1: "HELLO"}
+    assert prompt == {1: prompt_utils.RAW_HEADER_HINT + "\nHELLO"}
 
 
 def test_guide_miss(monkeypatch, tmp_path):

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -41,14 +41,21 @@ def test_prompts_for_pdf(tmp_path):
     path = tmp_path / "guide.csv"
     path.write_text("pdf,page,prompt\ndummy.pdf,,ALL\ndummy.pdf,2,TWO\n")
     mapping = prompt_utils.prompts_for_pdf("dummy.pdf", str(path))
-    assert mapping == {0: "ALL", 2: "TWO"}
+    assert mapping is not None
+    assert mapping[0].startswith(prompt_utils.RAW_HEADER_HINT)
+    assert mapping[2].startswith(prompt_utils.RAW_HEADER_HINT)
+    assert mapping[0].endswith("ALL")
+    assert mapping[2].endswith("TWO")
 
 
 def test_prompts_for_pdf_md(tmp_path):
     path = tmp_path / "guide.md"
     path.write_text("# G\n\n## BRAND\nPrompt\n")
     mapping = prompt_utils.prompts_for_pdf("BRAND_list.pdf", str(path))
-    assert mapping == {0: "Prompt"}
+    assert mapping is not None
+    assert list(mapping.keys()) == [0]
+    assert mapping[0].startswith(prompt_utils.RAW_HEADER_HINT)
+    assert mapping[0].endswith("Prompt")
 
 
 def test_prompts_for_pdf_no_match(tmp_path):


### PR DESCRIPTION
## Summary
- add `RAW_HEADER_HINT` constant describing common column headers
- prepend `RAW_HEADER_HINT` to prompts pulled from extraction guides
- use `RAW_HEADER_HINT` when falling back to the default prompt
- adjust tests for new prefix behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a32d300b8832fb9104b12e3bb2a9e