### PR TITLE
Add llm prompt debugging

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -240,6 +240,7 @@ def parse(
                 image_bytes = f.read()
             img_base64 = base64.b64encode(image_bytes).decode()
             prompt_text = _get_prompt(idx)
+            save_debug("llm_prompt", idx, prompt_text)
             logger.debug(
                 "Prompt being used for extraction (truncated): %s",
                 prompt_text[:200],

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -407,11 +407,10 @@ def save_master_dataset(
             existing = pd.DataFrame()
 
     if mode == "Güncelleme" and not existing.empty:
-        for col in ("Marka", "Yil", "Kaynak_Dosya"):
-            if col in df.columns and col in existing.columns:
-                values = df[col].dropna().unique()
-                if len(values):
-                    existing = existing[~existing[col].isin(values)]
+        if "Kaynak_Dosya" in df.columns and "Kaynak_Dosya" in existing.columns:
+            values = df["Kaynak_Dosya"].dropna().unique()
+            if len(values):
+                existing = existing[~existing["Kaynak_Dosya"].isin(values)]
 
         if "Kaynak_Dosya" in df.columns:
             for src in df["Kaynak_Dosya"].dropna().unique():


### PR DESCRIPTION
## Summary
- log prompts during OCR fallback
- extend Excel parser to handle more headers and missing code columns
- keep only matching source files when updating master dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a3a8f33cc832f9bfdc365964c1edd