### PR TITLE
Ensure prompts request JSON output

### DIFF
--- a/Price App/smart_price/core/prompt_utils.py
+++ b/Price App/smart_price/core/prompt_utils.py
@@ -157,6 +157,8 @@ def prompts_for_pdf(pdf_name: str, path: str | None = None) -> Dict[int, str] | 
         prompt = row.get("prompt")
         if not prompt:
             continue
+        if "json" not in prompt.lower():
+            prompt = prompt.rstrip() + "\nSonuçları JSON formatında döndür."
         page_val = row.get("page")
         if matched_name is None:
             matched_name = Path(str(file_field)).stem

--- a/tests/test_prompt_guide.py
+++ b/tests/test_prompt_guide.py
@@ -35,7 +35,8 @@ def _run_extract(tmp_path, guide_content, filename="dummy.pdf"):
 
 def test_guide_hit(monkeypatch, tmp_path):
     prompt = _run_extract(tmp_path, "pdf,page,prompt\ndummy.pdf,1,HELLO\n")
-    assert prompt == {1: prompt_utils.RAW_HEADER_HINT + "\nHELLO"}
+    expected = prompt_utils.RAW_HEADER_HINT + "\nHELLO\nSonuçları JSON formatında döndür."
+    assert prompt == {1: expected}
 
 
 def test_guide_miss(monkeypatch, tmp_path):

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -44,8 +44,8 @@ def test_prompts_for_pdf(tmp_path):
     assert mapping is not None
     assert mapping[0].startswith(prompt_utils.RAW_HEADER_HINT)
     assert mapping[2].startswith(prompt_utils.RAW_HEADER_HINT)
-    assert mapping[0].endswith("ALL")
-    assert mapping[2].endswith("TWO")
+    assert mapping[0].splitlines()[-1] == "Sonuçları JSON formatında döndür."
+    assert mapping[2].splitlines()[-1] == "Sonuçları JSON formatında döndür."
 
 
 def test_prompts_for_pdf_md(tmp_path):
@@ -55,7 +55,7 @@ def test_prompts_for_pdf_md(tmp_path):
     assert mapping is not None
     assert list(mapping.keys()) == [0]
     assert mapping[0].startswith(prompt_utils.RAW_HEADER_HINT)
-    assert mapping[0].endswith("Prompt")
+    assert mapping[0].splitlines()[-1] == "Sonuçları JSON formatında döndür."
 
 
 def test_prompts_for_pdf_no_match(tmp_path):
@@ -73,4 +73,12 @@ def test_parse_md_guide_stops_at_json(tmp_path):
     assert len(data) == 1
     prompt = data[0]["prompt"]
     assert "foo" not in prompt and "bar" not in prompt
+
+
+def test_prompts_append_json_hint(tmp_path):
+    path = tmp_path / "guide.csv"
+    path.write_text("pdf,page,prompt\ndummy.pdf,,Some instructions\n")
+    mapping = prompt_utils.prompts_for_pdf("dummy.pdf", str(path))
+    assert mapping is not None
+    assert mapping[0].splitlines()[-1] == "Sonuçları JSON formatında döndür."
 


### PR DESCRIPTION
## Summary
- tweak `prompts_for_pdf` so guide prompts always mention JSON output
- update tests for new prompt hint and add coverage for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ab7bc7144832fac6fb53cd8c7387f