### PR TITLE
Handle HTTP 404 in GitHub upload

### DIFF
--- a/Price App/smart_price/core/github_upload.py
+++ b/Price App/smart_price/core/github_upload.py
@@ -78,6 +78,12 @@ def upload_folder(
         try:
             resp = _api_request("GET", f"{url}?ref={branch}", token)
             sha = resp.get("sha")
+        except error.HTTPError as exc:  # pragma: no cover - network errors
+            if exc.code == 404:
+                sha = None
+            else:
+                logger.error("Failed to fetch existing file %s: %s", repo_path, exc)
+                sha = None
         except Exception as exc:  # pragma: no cover - network errors
             logger.error("Failed to fetch existing file %s: %s", repo_path, exc)
             sha = None


### PR DESCRIPTION
## Summary
- treat 404 errors from GitHub as normal
- test that upload_folder ignores 404 GET failures

## Testing
- `pytest -q tests/test_github_upload.py`

------
https://chatgpt.com/codex/tasks/task_b_684af0485910832fbb7c3c63c4998238