### PR TITLE
Include src/utils in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ pip install .
 pip install .[agentic]  # optional AgenticDE support
 ```
 
+The helper modules under `src/utils` are included automatically when
+installing from the repository.
+
 `tkinter` must also be available. It is typically included with many Python distributions but may require a separate installation on some systems.
 
 Smart_Price supports **Python 3.8** through **3.12**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-where = ["Price App", "Sales App"]
+where = ["Price App", "Sales App", "src"]
 
 [project.optional-dependencies]
 agentic = [


### PR DESCRIPTION
## Summary
- add `src` to setuptools package search so `utils` is installed
- mention that helper utilities install automatically

## Testing
- `python -m pip install -e .`
- `python - <<'EOF'
import importlib, pkgutil
module = importlib.import_module('utils.prompt_builder')
print('Imported', module.__name__)
print('File', module.__file__)
EOF`


------
https://chatgpt.com/codex/tasks/task_b_684b529c35fc832fa7c390707c9e94df