### PR TITLE
Refactor guide path resolution

### DIFF
--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -3,8 +3,36 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
-from utils.prompt_builder import get_prompt_for_file
+from pathlib import Path
+import importlib
+
+import utils.prompt_builder as pb
 
 def test_matrix_slug():
-    prompt = get_prompt_for_file("MATRIX Fiyat Listesi 10.03.25.pdf")
+    prompt = pb.get_prompt_for_file("MATRIX Fiyat Listesi 10.03.25.pdf")
     assert 'Marka = "MATRIX"' in prompt
+
+
+def test_guide_path_env(monkeypatch, tmp_path):
+    guide = tmp_path / "guide.md"
+    guide.write_text("## 0\n---\n## 1\n---")
+    monkeypatch.setenv("PRICE_GUIDE_PATH", str(guide))
+    mod = importlib.reload(pb)
+    assert mod.GUIDE_PATH == guide
+
+
+def test_guide_path_cwd(monkeypatch, tmp_path):
+    guide = tmp_path / "extraction_guide.md"
+    guide.write_text("## 0\n---")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PRICE_GUIDE_PATH", raising=False)
+    mod = importlib.reload(pb)
+    assert mod.GUIDE_PATH == guide
+
+
+def test_guide_path_default(monkeypatch):
+    repo_root = Path(__file__).resolve().parent.parent
+    monkeypatch.chdir(repo_root)
+    monkeypatch.delenv("PRICE_GUIDE_PATH", raising=False)
+    mod = importlib.reload(pb)
+    assert mod.GUIDE_PATH == repo_root / "extraction_guide.md"


### PR DESCRIPTION
## Summary
- rework prompt_builder to resolve GUIDE_PATH from env var `PRICE_GUIDE_PATH`
- add fallback to current working directory
- default to package path
- extend prompt_builder tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b54f2ba50832f897f713cc519df0b