### PR TITLE
Update setuptools packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install .
 pip install .[agentic]  # optional AgenticDE support
 ```
 
-The helper modules under `src/utils` are included automatically when
+The helper modules under `utils` are included automatically when
 installing from the repository.
 
 `tkinter` must also be available. It is typically included with many Python distributions but may require a separate installation on some systems.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,10 @@ dependencies = [
     "jsonschema>=4.22.0",
 ]
 
-[tool.setuptools.packages.find]
-where = ["Price App", "Sales App", "src"]
+[tool.setuptools]
+package-dir = {"" = "Price App"}
+packages = ["smart_price", "sales_app"]
+include-package-data = true
 
 [project.optional-dependencies]
 agentic = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,4 +3,3 @@ from pathlib import Path
 root = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(root / "Price App"))
 sys.path.insert(0, str(root / "Sales App"))
-sys.path.insert(0, str(root / "src"))


### PR DESCRIPTION
## Summary
- update setuptools config to specify package dir and packages
- adjust README wording
- drop unused `src` path entry from tests

## Testing
- `pytest -q` *(fails: FakeDF TypeError)*

------
https://chatgpt.com/codex/tasks/task_b_684b6cfb7f04832fbed9503482e836ab