### PR TITLE
Clean up test imports

### DIFF
--- a/tests/test_agentic_pdf.py
+++ b/tests/test_agentic_pdf.py
@@ -10,10 +10,6 @@ try:
     HAS_PANDAS = True
 except ModuleNotFoundError:  # pragma: no cover - optional dep
     HAS_PANDAS = False
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_agentic_pdf_columns(monkeypatch):
     header = ["Malzeme_Kodu", "Açıklama", "Fiyat"]

--- a/tests/test_big_alert.py
+++ b/tests/test_big_alert.py
@@ -1,8 +1,5 @@
-import os
 import sys
 import types
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from smart_price import icons
 

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -1,6 +1,4 @@
-import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from smart_price.core.common_utils import safe_json_parse
 

--- a/tests/test_extract_pdf.py
+++ b/tests/test_extract_pdf.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-# Ensure repo root is on path for package imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from tests.helpers import extract_pdf
 
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,12 +1,7 @@
-import os
 import sys
 import types
 import importlib
 import logging
-
-# Ensure repo root is on path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 def _import_module(monkeypatch):
     """Import extract_excel with minimal stubs if pandas is missing."""

--- a/tests/test_llm_extract.py
+++ b/tests/test_llm_extract.py
@@ -40,9 +40,6 @@ if 'dotenv' not in sys.modules:
     dotenv_stub.load_dotenv = lambda: None
     sys.modules['dotenv'] = dotenv_stub
 
-# Ensure repo root is on path for project imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 import smart_price.core.extract_pdf as ep  # noqa: E402
 from smart_price.core.extract_pdf import extract_from_pdf  # noqa: E402
 

--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -20,9 +20,6 @@ dotenv_stub = types.ModuleType('dotenv')
 dotenv_stub.load_dotenv = lambda *_args, **_kw: None
 sys.modules['dotenv'] = dotenv_stub
 
-# Ensure repo root is on path for imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 openai_calls = {}
 
 def _setup_openai(monkeypatch):

--- a/tests/test_page_summary.py
+++ b/tests/test_page_summary.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import types
 import pytest
@@ -19,7 +18,6 @@ dotenv_stub.load_dotenv = lambda *_args, **_kw: None
 sys.modules['dotenv'] = dotenv_stub
 
 # Ensure repo root is on path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 try:
     import pandas as pd  # noqa: F401

--- a/tests/test_parser_df.py
+++ b/tests/test_parser_df.py
@@ -1,8 +1,5 @@
-import os
 import sys
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 try:
     import pandas as pd  # noqa: F401

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -1,6 +1,4 @@
-import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import types
 import pytest
 

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,9 +1,3 @@
-import os
-import sys
-
-# Ensure Price App package is on path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Price App")))
-
 from pathlib import Path
 import importlib
 

--- a/tests/test_prompt_guide.py
+++ b/tests/test_prompt_guide.py
@@ -1,10 +1,6 @@
 import sys
 import types
 
-# Ensure repo root on path
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from smart_price import config
 import smart_price.core.extract_pdf as pdf_mod
 from smart_price.core import prompt_utils

--- a/tests/test_prompt_utils.py
+++ b/tests/test_prompt_utils.py
@@ -1,8 +1,4 @@
-import os
-import sys
 import json
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from smart_price.core import prompt_utils
 from smart_price import config

--- a/tests/test_sales_app.py
+++ b/tests/test_sales_app.py
@@ -1,12 +1,7 @@
 import os
-import sys
 import sqlite3
+import sys
 import types
-
-root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, root_dir)
-sys.path.insert(0, os.path.join(root_dir, "Price App"))
-sys.path.insert(0, os.path.join(root_dir, "Sales App"))
 
 _pandas_stubbed = False
 try:  # pragma: no cover - pandas may not be installed

--- a/tests/test_save_master_dataset.py
+++ b/tests/test_save_master_dataset.py
@@ -1,11 +1,8 @@
-import os
 import sys
 import types
 import sqlite3
 from pathlib import Path
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Try to import pandas
 try:

--- a/tests/test_standardize_columns.py
+++ b/tests/test_standardize_columns.py
@@ -1,9 +1,6 @@
-import os
 import sys
 import types
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 try:
     import pandas as pd  # noqa: F401

--- a/tests/test_validate_df.py
+++ b/tests/test_validate_df.py
@@ -1,6 +1,4 @@
-import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pandas as pd
 from smart_price.core.common_utils import validate_output_df, EXTRACTION_FIELDS


### PR DESCRIPTION
## Summary
- remove per-test `sys.path` hacks
- import `prompt_builder` directly

## Testing
- `pytest -q` *(fails: AttributeError and TypeError in some tests)*

------
https://chatgpt.com/codex/tasks/task_b_684b6ece0350832f889ea96afc7fe1cf