### PR TITLE
Update README install and utility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ Akıllı Fiyat Asistanı
 The required Python packages are listed in `pyproject.toml`. Install them together with this project using `pip`:
 
 ```bash
-pip install .
-pip install .[agentic]  # optional AgenticDE support
+pip install -e .
+# or
+pip install smart-price
 ```
 
-The helper modules under `utils` are included automatically when
-installing from the repository.
+Utilities live under `smart_price.utils`.
+
+```python
+from smart_price.utils.prompt_builder import get_prompt_for_file
+```
 
 `tkinter` must also be available. It is typically included with many Python distributions but may require a separate installation on some systems.
 


### PR DESCRIPTION
## Summary
- document editable install options
- note `smart_price.utils` module location
- show usage example for `get_prompt_for_file`

## Testing
- `ruff check .` *(fails: Found 40 errors)*
- `pytest -q` *(fails: 8 failed, 43 passed, 39 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_684b70cc0ab4832fad23d1f1e7978a98