### PR TITLE
Switch debug images to JPEG

### DIFF
--- a/Price App/smart_price/core/debug_utils.py
+++ b/Price App/smart_price/core/debug_utils.py
@@ -64,9 +64,15 @@ def save_debug_image(prefix: str, page: int, image: Image.Image) -> Optional[Pat
         Path of the saved image if it could be written, otherwise ``None``.
     """
     dir_path = _debug_dir()
-    file_path = dir_path / f"{prefix}_page_{page:02d}.png"
+    file_path = dir_path / f"{prefix}_page_{page:02d}.jpg"
     try:
-        image.save(file_path, format="PNG")
+        image.save(
+            file_path,
+            format="JPEG",
+            quality=80,
+            optimize=True,
+            progressive=True,
+        )
     except Exception as exc:  # pragma: no cover - debug file failures
         logger.debug("debug image write failed for %s: %s", file_path, exc)
     return file_path

--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -270,7 +270,7 @@ def extract_from_pdf(
         ok = upload_folder(
             debug_dir,
             remote_prefix=f"LLM_Output_db/{debug_dir.name}",
-            file_extensions=[".png"],
+            file_extensions=[".jpg"],
         )
         if ok:
             notify("Debug klasörü yüklendi")
@@ -308,7 +308,7 @@ def extract_from_pdf(
         + (result.groupby("Sayfa").cumcount() + 1).astype(str)
     )
     result["Image_Path"] = result["Sayfa"].apply(
-        lambda page_num: f"LLM_Output_db/{sanitized_base}/page_image_page_{int(page_num):02d}.png"
+        lambda page_num: f"LLM_Output_db/{sanitized_base}/page_image_page_{int(page_num):02d}.jpg"
     )
     cols = [
         "Malzeme_Kodu",
@@ -339,9 +339,9 @@ def extract_from_pdf(
     text_dir = Path(os.getenv("SMART_PRICE_TEXT_DIR", "LLM_Text_db")) / output_stem
     debug_dir.mkdir(parents=True, exist_ok=True)
     text_dir.mkdir(parents=True, exist_ok=True)
-    if not any(p.suffix == ".png" for p in debug_dir.glob("*.png")):
+    if not any(p.suffix == ".jpg" for p in debug_dir.glob("*.jpg")):
         try:
-            with open(debug_dir / "page_image_page_01.png", "wb") as fh:
+            with open(debug_dir / "page_image_page_01.jpg", "wb") as fh:
                 fh.write(b"")
         except Exception:
             pass
@@ -356,7 +356,7 @@ def extract_from_pdf(
     ok = upload_folder(
         debug_dir,
         remote_prefix=f"LLM_Output_db/{debug_dir.name}",
-        file_extensions=[".png"],
+        file_extensions=[".jpg"],
     )
     if ok:
         notify("Debug klasörü yüklendi")

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -227,8 +227,14 @@ def parse(
         tmp_path = img_path
         created_tmp = False
         if tmp_path is None:
-            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".png")
-            img.save(tmp.name, format="PNG")
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".jpg")
+            img.save(
+                tmp.name,
+                format="JPEG",
+                quality=80,
+                optimize=True,
+                progressive=True,
+            )
             tmp.close()
             tmp_path = Path(tmp.name)
             created_tmp = True
@@ -256,7 +262,7 @@ def parse(
                             {
                                 "type": "image_url",
                                 "image_url": {
-                                    "url": "data:image/png;base64," + img_base64
+                                    "url": "data:image/jpeg;base64," + img_base64
                                 },
                             },
                         ],
@@ -414,7 +420,7 @@ def parse(
     ok = upload_folder(
         debug_dir,
         remote_prefix=f"LLM_Output_db/{debug_dir.name}",
-        file_extensions=[".png"],
+        file_extensions=[".jpg"],
     )
     if ok:
         logger.info("Debug klasörü yüklendi")

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The log records extra details to help trace each step:
 - per-page LLM responses stored under `LLM_Text_db/<PDF adı>` (set
   `SMART_PRICE_TEXT_DIR` to override the location)
 Debug images can be downloaded directly from GitHub using a URL like
-`https://raw.githubusercontent.com/<owner>/<repo>/main/LLM_Output_db/<PDF adı>/page_image_page_<NN>.png`.
+`https://raw.githubusercontent.com/<owner>/<repo>/main/LLM_Output_db/<PDF adı>/page_image_page_<NN>.jpg`.
 Note that the `LLM_Output_db` folder sits at the repository root; **do not**
 prefix the path with `Master_data_base`. Only the images in this folder are
 uploaded automatically; text files remain in `LLM_Text_db`.

--- a/Sales App/sales_app/streamlit_app.py
+++ b/Sales App/sales_app/streamlit_app.py
@@ -184,7 +184,7 @@ def search_page(df: pd.DataFrame) -> None:
                     if page_num is not None:
                         img_url = (
                             f"{base}/LLM_Output_db/{folder}/"
-                            f"page_image_page_{page_num:02d}.png"
+                            f"page_image_page_{page_num:02d}.jpg"
                         )
         if img_url:
             try:

--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -80,7 +80,7 @@ def test_parse_sends_bytes_and_cleans_tmp(monkeypatch):
 
     assert 'images' not in openai_calls
     first_msg = openai_calls['messages'][0]
-    assert first_msg['content'][1]['image_url']['url'].startswith('data:image/png;base64,')
+    assert first_msg['content'][1]['image_url']['url'].startswith('data:image/jpeg;base64,')
     for path in temp_paths:
         assert not os.path.exists(path)
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -889,7 +889,7 @@ def test_llm_debug_files(monkeypatch, tmp_path):
     txt_folder = txt_root / "dummy"
 
     assert not df.empty
-    assert any(p.suffix == ".png" for p in img_folder.iterdir())
+    assert any(p.suffix == ".jpg" for p in img_folder.iterdir())
     assert any(p.name.startswith("llm_response") for p in txt_folder.iterdir())
 
 
@@ -968,7 +968,7 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
             "Para_Birimi": ["₺"],
             "Kaynak_Dosya": ["src.xlsx"],
             "Sayfa": [1],
-            "Image_Path": ["img.png"],
+            "Image_Path": ["img.jpg"],
             "Record_Code": ["R1"],
             "Yil": [2024],
             "Marka": ["Brand"],
@@ -1022,7 +1022,7 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
         "₺",
         "src.xlsx",
         1,
-        "img.png",
+        "img.jpg",
         "R1",
         2024,
         "Brand",


### PR DESCRIPTION
## Summary
- store debug images as JPG rather than PNG
- update all references to the new extension
- adjust tests for JPEG

## Testing
- `pytest -q` *(fails: KeyError, ValueError, network errors)*

------
https://chatgpt.com/codex/tasks/task_b_684b75bfa224832fb0f96f088b0ebf1b