### PR TITLE
Retry OpenAI timeouts

### DIFF
--- a/Price App/smart_price/core/debug_utils.py
+++ b/Price App/smart_price/core/debug_utils.py
@@ -66,13 +66,7 @@ def save_debug_image(prefix: str, page: int, image: Image.Image) -> Optional[Pat
     dir_path = _debug_dir()
     file_path = dir_path / f"{prefix}_page_{page:02d}.jpg"
     try:
-        image.save(
-            file_path,
-            format="JPEG",
-            quality=80,
-            optimize=True,
-            progressive=True,
-        )
+        image.save(file_path, format="JPEG")
     except Exception as exc:  # pragma: no cover - debug file failures
         logger.debug("debug image write failed for %s: %s", file_path, exc)
     return file_path


### PR DESCRIPTION
## Summary
- handle `TimeoutError` by requeueing the page
- note timeout retries in summary
- pass `timeout=120` to OpenAI calls
- simplify debug image saving
- test timeout retries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b7d54a558832f85be22ca35c44608