### PR TITLE
Adjust tests for JPG debug images

### DIFF
--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -6,6 +6,8 @@ import time
 import threading
 import logging
 
+from smart_price.core.extract_pdf import PAGE_IMAGE_EXT
+
 # Provide minimal stubs for optional deps before importing project code
 if 'PIL' not in sys.modules:
     pil_stub = types.ModuleType('PIL')
@@ -80,7 +82,8 @@ def test_parse_sends_bytes_and_cleans_tmp(monkeypatch):
 
     assert 'images' not in openai_calls
     first_msg = openai_calls['messages'][0]
-    assert first_msg['content'][1]['image_url']['url'].startswith('data:image/jpeg;base64,')
+    mime = "jpeg" if PAGE_IMAGE_EXT in {".jpg", ".jpeg"} else PAGE_IMAGE_EXT.lstrip(".")
+    assert first_msg['content'][1]['image_url']['url'].startswith(f'data:image/{mime};base64,')
     for path in temp_paths:
         assert not os.path.exists(path)
 

--- a/tests/test_price_parser.py
+++ b/tests/test_price_parser.py
@@ -41,7 +41,7 @@ from smart_price.core.common_utils import detect_brand
 from smart_price.core.common_utils import split_code_description
 from smart_price.core.common_utils import gpt_clean_text
 from smart_price.core.extract_excel import extract_from_excel
-from smart_price.core.extract_pdf import extract_from_pdf
+from smart_price.core.extract_pdf import extract_from_pdf, PAGE_IMAGE_EXT
 
 if HAS_PANDAS:
     from smart_price import streamlit_app
@@ -889,7 +889,7 @@ def test_llm_debug_files(monkeypatch, tmp_path):
     txt_folder = txt_root / "dummy"
 
     assert not df.empty
-    assert any(p.suffix == ".jpg" for p in img_folder.iterdir())
+    assert any(p.suffix == PAGE_IMAGE_EXT for p in img_folder.iterdir())
     assert any(p.name.startswith("llm_response") for p in txt_folder.iterdir())
 
 
@@ -968,7 +968,7 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
             "Para_Birimi": ["₺"],
             "Kaynak_Dosya": ["src.xlsx"],
             "Sayfa": [1],
-            "Image_Path": ["img.jpg"],
+            "Image_Path": [f"img{PAGE_IMAGE_EXT}"],
             "Record_Code": ["R1"],
             "Yil": [2024],
             "Marka": ["Brand"],
@@ -1022,7 +1022,7 @@ def test_price_parser_db_schema(monkeypatch, tmp_path):
         "₺",
         "src.xlsx",
         1,
-        "img.jpg",
+        f"img{PAGE_IMAGE_EXT}",
         "R1",
         2024,
         "Brand",


### PR DESCRIPTION
## Summary
- update tests to reference the `PAGE_IMAGE_EXT` constant instead of a hard-coded `.jpg`
- expect JPEG debug output in OCR fallback test

## Testing
- `pytest -q` *(fails: FakeDF.__init__() got an unexpected keyword argument 'columns')*

------
https://chatgpt.com/codex/tasks/task_b_684bd3aae734832fbb574b84eb2e8a97