### PR TITLE
Fix editable install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ pip install -e .
 # or
 pip install smart-price
 ```
+This project uses explicit package mappings in `pyproject.toml`, so the
+editable install works on Windows and other platforms.
 
 Utilities live under `smart_price.utils`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 ]
 
 [tool.setuptools]
-package-dir = {"" = "Price App"}
+package-dir = { "smart_price" = "Price App/smart_price", "sales_app" = "Sales App/sales_app" }
 packages = ["smart_price", "sales_app"]
 include-package-data = true
 


### PR DESCRIPTION
## Summary
- tweak package directories for setuptools
- note cross-platform install in README

## Testing
- `pip install -e .`
- `ruff check .` *(fails: E402 Module level import not at top of file)*
- `black --check .` *(fails: would reformat files)*
- `pytest -q` *(fails: 5 failed, 85 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_684bdb7044cc832f829029b3330e997d