### PR TITLE
Add logging for merge processing and save steps

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -340,6 +340,7 @@ def merge_files(
                 except Exception:
                     pass
 
+        logger.info("==> FILE %s extraction done rows=%s", up_file.name, len(df))
         if update_progress:
             update_progress(idx / total)
 
@@ -665,10 +666,12 @@ def upload_page():
             return
         try:
             with st.spinner("Kaydediliyor..."):
+                logger.info("==> BEGIN save_master_dataset")
                 excel_path, db_path, upload_result = save_master_dataset(
                     df,
                     mode=st.session_state.get("upload_mode", "Yeni fiyat listesi"),
                 )
+                logger.info("==> END save_master_dataset")
         except Exception as exc:  # pragma: no cover - UI feedback only
             big_alert(f"Kaydetme hatası: {exc}", level="error")
         else:


### PR DESCRIPTION
## Summary
- log each file's extraction result in merge_files
- log the start and end of save_master_dataset when saving

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c0d26ada0832f9543fe2c4025bad4