### PR TITLE
Add timeout option to GitHub uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ uploaded automatically; text files remain in `LLM_Text_db`.
    `master_dataset.xlsx` and `master.db`) to the configured repository
    under their respective folders (optionally specify `GITHUB_BRANCH`).
    If these variables are not set the upload is skipped gracefully.
+ - set `GITHUB_HTTP_TIMEOUT` to change the HTTP timeout for GitHub API
+   requests in seconds (defaults to `30`).
 
 ### Resetting the dataset
 


### PR DESCRIPTION
## Summary
- support configurable timeouts in `github_upload` helpers
- document `GITHUB_HTTP_TIMEOUT`
- test that timeouts are forwarded and raise errors

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c1b6e6234832f94401e620cf2b7d3