### PR TITLE
fix(prompt_builder): capture universal synonym map

### DIFF
--- a/Price App/smart_price/utils/prompt_builder.py
+++ b/Price App/smart_price/utils/prompt_builder.py
@@ -56,13 +56,13 @@ class _GuideCache:
         if not md_path.exists():
             raise FileNotFoundError(md_path)
         text = md_path.read_text(encoding="utf-8").replace("\r\n", "\n")
-        self.global_block   = self._section(text, r"##\s*0[\s\S]+?---")
-        self.synonym_block  = self._section(text, r"##\s*1[\s\S]+?---")
-        self.generic_block  = self._section(text, r"##\s*2[\s\S]+?---")
+        self.global_block   = self._section(text, r"##\s*0[\s\S]+?\n---\n")
+        self.synonym_block  = self._section(text, r"##\s*1[\s\S]+?\n---\n")
+        self.generic_block  = self._section(text, r"##\s*2[\s\S]+?\n---\n")
         pattern = re.compile(r"###\s*3\.\d+\s+([^\n]+)\n([\s\S]+?)(?=\n###\s*3\.|\n##\s*4\s*·|\Z)")
         for m in pattern.finditer(text):
             self.brand_blocks[m[1].strip()] = m[2].strip()
-        self.default_block = self._section(text, r"##\s*4[\s\S]+?---")
+        self.default_block = self._section(text, r"##\s*4[\s\S]+?\n---\n")
         self._loaded = True
 
     @staticmethod

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -31,3 +31,12 @@ def test_guide_path_default(monkeypatch):
     monkeypatch.delenv("PRICE_GUIDE_PATH", raising=False)
     mod = importlib.reload(pb)
     assert mod.GUIDE_PATH == repo_root / "extraction_guide.md"
+
+
+def test_synonym_block_in_prompt(monkeypatch):
+    repo_root = Path(__file__).resolve().parent.parent
+    guide = repo_root / "extraction_guide.md"
+    monkeypatch.setenv("PRICE_GUIDE_PATH", str(guide))
+    mod = importlib.reload(pb)
+    prompt = mod.get_prompt_for_file("dummy.pdf")
+    assert "accept any of these header texts" in prompt.lower()


### PR DESCRIPTION
## Summary
- capture entire universal synonym map section when building prompts
- test that generated prompts include header synonym table

## Testing
- `pytest -k "prompt_builder or prompt_utils" -q`

------
https://chatgpt.com/codex/tasks/task_b_684c45dc1c78832f9ceb5118b1049fe2