### PR TITLE
Configure OpenAI retry defaults

### DIFF
--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -155,6 +155,11 @@ def extract_from_pdf(
             openai_max_retries = int(os.getenv("OPENAI_MAX_RETRIES", "0"))
         except Exception:
             openai_max_retries = 0
+        try:  # pragma: no cover - openai may not expose this attr
+            import openai as _openai
+            _openai.api_requestor._DEFAULT_NUM_RETRIES = openai_max_retries
+        except Exception:
+            pass
 
         client = OpenAI(api_key=api_key, max_retries=openai_max_retries)
 
@@ -175,7 +180,6 @@ def extract_from_pdf(
                 model=model_name,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.2,
-                max_retries=openai_max_retries,
             )
             logger.info("OpenAI request took %.2fs", time.time() - start_llm)
             time.sleep(0.5)

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -245,6 +245,10 @@ def parse(
         openai_max_retries = int(os.getenv("OPENAI_MAX_RETRIES", "0"))
     except Exception:
         openai_max_retries = 0
+    try:  # pragma: no cover - openai may not expose this attr
+        openai.api_requestor._DEFAULT_NUM_RETRIES = openai_max_retries
+    except Exception:
+        pass
 
     def _get_prompt(page: int) -> str:
         fallback = RAW_HEADER_HINT + "\n" + DEFAULT_PROMPT
@@ -329,7 +333,6 @@ def parse(
                 response_format={"type": "json_object"},
                 temperature=0,
                 timeout=120,
-                max_retries=openai_max_retries,
             )
             logger.info(
                 "OpenAI request for page %d took %.2fs", idx, time.time() - api_start

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ and how to return the rows as JSON with fields like *Malzeme_Kodu*, *Fiyat*,
 *Açıklama*, *Adet*, *Birim*, *Para_Birimi*, *Marka* and *Kutu_Adedi*. Provide an
 `OPENAI_API_KEY` environment variable or a `.env` file containing the key to
 enable this step. Optionally set `OPENAI_MODEL` to override the default
-`gpt-4o` model. Set `OPENAI_MAX_RETRIES` to limit automatic retries by
-the OpenAI client (defaults to `0`). The Vision API is queried with a
-temperature of `0`.
+`gpt-4o` model. Set `OPENAI_MAX_RETRIES` to update
+`openai.api_requestor._DEFAULT_NUM_RETRIES` (defaults to `0`). The
+request itself no longer passes a `max_retries` argument and the Vision
+API is queried with a temperature of `0`.
 
 ### Agentic document extraction
 

--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -33,7 +33,10 @@ def _setup_openai(monkeypatch):
             choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='[]'))]
         )
     chat_stub = types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
-    openai_stub = types.SimpleNamespace(chat=chat_stub)
+    openai_stub = types.SimpleNamespace(
+        chat=chat_stub,
+        api_requestor=types.SimpleNamespace(_DEFAULT_NUM_RETRIES=None),
+    )
     monkeypatch.setitem(sys.modules, 'openai', openai_stub)
     monkeypatch.setenv('OPENAI_API_KEY', 'x')
     monkeypatch.setenv('MAX_RETRY_WAIT_TIME', '0')
@@ -107,7 +110,8 @@ def test_openai_max_retries_env(monkeypatch):
 
     mod.parse("dummy.pdf")
 
-    assert openai_calls.get("max_retries") == 5
+    openai_mod = sys.modules["openai"]
+    assert openai_mod.api_requestor._DEFAULT_NUM_RETRIES == 5
 
 
 def test_openai_max_retries_default(monkeypatch):
@@ -126,7 +130,8 @@ def test_openai_max_retries_default(monkeypatch):
 
     mod.parse("dummy.pdf")
 
-    assert openai_calls.get("max_retries") == 0
+    openai_mod = sys.modules["openai"]
+    assert openai_mod.api_requestor._DEFAULT_NUM_RETRIES == 0
 
 
 def test_parse_parallel_execution(monkeypatch):


### PR DESCRIPTION
## Summary
- adjust OpenAI usage so `OPENAI_MAX_RETRIES` sets `api_requestor._DEFAULT_NUM_RETRIES`
- stop passing `max_retries` to chat completions
- update OCR fallback tests for the new behaviour
- document retry behaviour in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c45747ae4832fae4dc14eb375429e