### PR TITLE
Add logging and limit PDF pages

### DIFF
--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -261,6 +261,7 @@ def extract_from_pdf(
                 path_for_llm,
                 output_name=output_stem if tmp_for_llm else None,
                 prompt=guide_prompt,
+                page_range=range(1, 4),
                 progress_callback=progress_callback,
             )
         except TypeError:
@@ -269,9 +270,10 @@ def extract_from_pdf(
                     path_for_llm,
                     output_name=output_stem if tmp_for_llm else None,
                     prompt=guide_prompt,
+                    page_range=range(1, 4),
                 )
             except TypeError:
-                result = ocr_llm_fallback.parse(path_for_llm)
+                result = ocr_llm_fallback.parse(path_for_llm, page_range=range(1, 4))
         logger.info("==> END vision_loop rows=%s", len(result))
         logger.info(
             "==> END images_from_pdf pages=%s",

--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -291,6 +291,7 @@ def merge_files(
     update_dataframe:
         Optional callable receiving the merged DataFrame after each file.
     """
+    logger.info("==> BEGIN merge_files count=%s", len(uploaded_files))
     extracted = []
     token_totals: dict[str, dict[str, int]] = {}
     total_rows = 0
@@ -300,6 +301,7 @@ def merge_files(
             update_status("Dosya y\u00fckleniyor, l\u00fctfen bekleyin...", "info")
         if update_progress:
             update_progress((idx - 1) / total)
+        logger.info("==> FILE %s processing start", up_file.name)
 
         page_idx = 0
         total_pages: int | None = None
@@ -433,6 +435,7 @@ def merge_files(
     if hasattr(master, "__dict__"):
         object.__setattr__(master, "token_totals", token_totals)
         object.__setattr__(master, "total_tokens", total_tokens)
+    logger.info("==> END merge_files rows=%s", len(master))
     return master
 
 


### PR DESCRIPTION
## Summary
- limit OCR+LLM pipeline to the first three pages when parsing PDFs
- add detailed logging in the vision loop and parse steps
- log retries, splits and start/end of merge operations

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c91fb7e2c832fb5c9c184df42cda8