### PR TITLE
Handle GitHub upload conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ uploaded automatically; text files remain in `LLM_Text_db`.
    If these variables are not set the upload is skipped gracefully.
  - set `GITHUB_HTTP_TIMEOUT` to change the HTTP timeout for GitHub API
    requests in seconds (defaults to `30`).
+ - uploads automatically retry on HTTP 409 conflicts using the
+   latest file SHA and skip unchanged files.
 
 ### Resetting the dataset
 


### PR DESCRIPTION
## Summary
- handle GitHub HTTP 409 errors in `upload_folder`
- add a regression test for conflict handling
- mention auto retry behaviour in the README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c98d79644832fb9a16a1093fc032c