### PR TITLE
Allow configuring progress batch size

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -38,7 +38,8 @@ right_logo_url = ROOT / "logo" / "sadece_dp_seffaf.PNG"
 logger = logging.getLogger("smart_price")
 
 # Number of pages to process before showing progress information
-BATCH_SIZE = 5
+# Can be overridden using the ``SP_PROGRESS_BATCH_SIZE`` environment variable.
+BATCH_SIZE = int(os.getenv("SP_PROGRESS_BATCH_SIZE", "5"))
 
 
 def standardize_column_names(df: pd.DataFrame) -> pd.DataFrame:

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ MAX_RETRY_WAIT_TIME=30
 # Logging style for retries: log_msg, inline_block or none
 RETRY_LOGGING_STYLE=log_msg
 ```
-
 These values configure the internal `agentic_doc` Settings object.  The
 optimal numbers depend on your API rate limit and document size. The same
 `MAX_RETRIES` and `MAX_RETRY_WAIT_TIME` variables control how often the
 fallback OCR+LLM parser re-attempts timed out requests.
+
+Use ``SP_PROGRESS_BATCH_SIZE`` to change how many PDF pages the
+Streamlit interface processes before showing a progress message (default ``5``).
 
 ``agentic_doc.parse`` now returns a list of ``ParsedDocument`` objects. The
 tools use the first item in that list. When an extraction guide provides

--- a/tests/test_progress_batch.py
+++ b/tests/test_progress_batch.py
@@ -1,0 +1,11 @@
+import importlib
+from tests.test_big_alert import _setup_streamlit
+
+
+def test_batch_size_env(monkeypatch):
+    _setup_streamlit(monkeypatch)
+    monkeypatch.setenv("SP_PROGRESS_BATCH_SIZE", "7")
+    import smart_price.streamlit_app as app
+    app = importlib.reload(app)
+    assert app.BATCH_SIZE == 7
+


### PR DESCRIPTION
## Summary
- allow configuring progress updates per PDF by reading `SP_PROGRESS_BATCH_SIZE`
- document the new env var in README
- add a regression test for the env override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c9d980bc4832fbf6a8bf59eb37659