### PR TITLE
Improve logging in merge_files

### DIFF
--- a/Price App/smart_price/streamlit_app.py
+++ b/Price App/smart_price/streamlit_app.py
@@ -391,6 +391,12 @@ def merge_files(
     if "Malzeme_Kodu" not in master.columns:
         logger.warning("[merge] 'Malzeme_Kodu' column missing after merge")
         master["Malzeme_Kodu"] = None
+    # Diagnostic logging before dropping rows
+    logger.warning(f"[merge] DF column names: {master.columns.tolist()}")
+    logger.warning(
+        f"[merge] DF Malzeme_Kodu sample: "
+        f"{master['Malzeme_Kodu'].dropna().head(5).tolist() if 'Malzeme_Kodu' in master.columns else 'COLUMN NOT FOUND'}"
+    )
     drop_mask = master[["Malzeme_Kodu", "Fiyat"]].isna().any(axis=1)
     dropped_preview = master[drop_mask].head().to_dict(orient="records")
     before_len = len(master)


### PR DESCRIPTION
## Summary
- add diagnostic logging in `merge_files` for column names and `Malzeme_Kodu` sample

## Testing
- `pytest -q` *(fails: AttributeError: 'dict' object has no attribute 'columns')*

------
https://chatgpt.com/codex/tasks/task_b_684ca3cefc44832f9147fa2911c47330