### PR TITLE
Handle 'products' root key in LLM JSON output

### DIFF
--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -189,6 +189,8 @@ def extract_from_pdf(
             try:
                 cleaned = gpt_clean_text(content)
                 items = safe_json_parse(cleaned)
+                if isinstance(items, dict) and "products" in items:
+                    items = items.get("products")
                 if items is None:
                     raise ValueError("parse failed")
                 logger.debug("First parsed items: %r", items[:2])

--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -374,6 +374,8 @@ def parse(
 
         cleaned = gpt_clean_text(content) if content else "[]"
         items = safe_json_parse(cleaned)
+        if isinstance(items, dict) and "products" in items:
+            items = items.get("products")
         if items is None:
             logger.error("LLM JSON parse failed on page %d", idx)
             status = "error"


### PR DESCRIPTION
## Summary
- align JSON parsing with extraction_guide instructions
- handle dictionaries with a `products` list in both parsing pipelines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684caf496da0832fbfe6370d5b758b2a