### PR TITLE
Add retry for connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ RETRY_LOGGING_STYLE=log_msg
 These values configure the internal `agentic_doc` Settings object.  The
 optimal numbers depend on your API rate limit and document size. The same
 `MAX_RETRIES` and `MAX_RETRY_WAIT_TIME` variables control how often the
-fallback OCR+LLM parser re-attempts timed out requests.
+fallback OCR+LLM parser re-attempts timed out or connection-error requests.
 
 Use ``SP_PROGRESS_BATCH_SIZE`` to change how many PDF pages the
 Streamlit interface processes before showing a progress message (default ``5``).


### PR DESCRIPTION
## Summary
- retry OpenAI connection errors in `ocr_llm_fallback`
- note connection errors in README
- test connection error retry logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ccb244504832fb584029fe6579591