### PR TITLE
Remove redundant wait_for wrapper

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -378,7 +378,7 @@ def parse(
                     timeout=openai_request_timeout,
                 )
 
-            resp = asyncio.run(asyncio.wait_for(_do_request(), openai_request_timeout))
+            resp = asyncio.run(_do_request())
             logger.info(
                 "OpenAI request for page %d took %.2fs", idx, time.time() - api_start
             )


### PR DESCRIPTION
## Summary
- rely on OpenAI client's timeout instead of outer `asyncio.wait_for`
- keep `OPENAI_REQUEST_TIMEOUT` env var for configuring OpenAI client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d7443f8b4832fa43f5f7f4c6ae819