### PR TITLE
Add worker/timeout logging

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -482,6 +482,7 @@ def parse(
     workers = int(os.getenv("SMART_PRICE_LLM_WORKERS", "5"))
     if len(images) <= 2:
         workers = 1
+    logger.info("vision_loop workers=%s timeout=%s", workers, openai_request_timeout)
     logger.info("==> BEGIN vision_loop")
     tasks = deque((i, img) for i, img in enumerate(images, start=1))
     results = []


### PR DESCRIPTION
## Summary
- log the worker count and OpenAI request timeout before starting the vision loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d869b5014832f80caf6093188bf37