### PR TITLE
Add OPENAI timeout configuration

### DIFF
--- a/Price App/smart_price/core/ocr_llm_fallback.py
+++ b/Price App/smart_price/core/ocr_llm_fallback.py
@@ -53,6 +53,14 @@ logger = logging.getLogger("smart_price")
 
 DEBUG = os.getenv("SMART_PRICE_DEBUG", "1") == "1"
 
+
+def _get_openai_timeout() -> float:
+    """Return ``OpenAI`` request timeout in seconds."""
+    try:
+        return float(os.getenv("OPENAI_REQUEST_TIMEOUT", "120"))
+    except Exception:
+        return 120.0
+
 DEFAULT_PROMPT = """
 Sen bir PDF fiyat listesi analiz asistanısın. Amacın, PDF’lerdeki ürün tablosu/ürün satırlarını ve bunların üst başlıklarını tam olarak, eksiksiz ve yapısal şekilde çıkarmaktır.
 
@@ -200,7 +208,10 @@ def parse(
         logger.error("OpenAI import failed: %s", exc)
         return pd.DataFrame()
 
-    client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+    client = OpenAI(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        timeout=_get_openai_timeout(),
+    )
     model_name = os.getenv("OPENAI_MODEL", "gpt-4o")
 
     def _get_prompt(page: int) -> str:

--- a/tests/test_page_summary.py
+++ b/tests/test_page_summary.py
@@ -80,6 +80,7 @@ def test_ocr_llm_fallback_summary(monkeypatch):
         return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=content))])
     openai_stub = types.SimpleNamespace(chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create)))
     openai_stub.AsyncOpenAI = lambda *a, **kw: openai_stub
+    openai_stub.OpenAI = openai_stub.AsyncOpenAI
     monkeypatch.setitem(sys.modules, 'openai', openai_stub)
     monkeypatch.setenv('OPENAI_API_KEY', 'x')
     monkeypatch.setenv('RETRY_DELAY_BASE', '0')


### PR DESCRIPTION
## Summary
- add helper `_get_openai_timeout` to read `OPENAI_REQUEST_TIMEOUT`
- pass timeout to `OpenAI`
- adjust tests for timeout behavior

## Testing
- `pytest tests/test_ocr_llm_fallback.py::test_openai_request_timeout -q`

------
https://chatgpt.com/codex/tasks/task_b_684dfe110300832f990523dfe2d18650