### PR TITLE
Fix duplicate OpenAI assignments

### DIFF
--- a/tests/test_ocr_llm_fallback.py
+++ b/tests/test_ocr_llm_fallback.py
@@ -173,10 +173,6 @@ def test_parse_parallel_execution(monkeypatch):
     openai_stub = types.SimpleNamespace(chat=chat_stub)
     openai_stub.AsyncOpenAI = lambda *a, **kw: openai_stub
     openai_stub.OpenAI = openai_stub.AsyncOpenAI
-    openai_stub.OpenAI = openai_stub.AsyncOpenAI
-    openai_stub.OpenAI = openai_stub.AsyncOpenAI
-    openai_stub.OpenAI = openai_stub.AsyncOpenAI
-    openai_stub.OpenAI = openai_stub.AsyncOpenAI
     monkeypatch.setitem(sys.modules, 'openai', openai_stub)
     monkeypatch.setenv('OPENAI_API_KEY', 'x')
     monkeypatch.setenv('RETRY_DELAY_BASE', '0')


### PR DESCRIPTION
## Summary
- cleanup redundant assignments in `test_ocr_llm_fallback.py`

## Testing
- `pytest -q tests/test_ocr_llm_fallback.py::test_parse_parallel_execution`
- `pytest -q tests/test_ocr_llm_fallback.py`


------
https://chatgpt.com/codex/tasks/task_b_6857ecec768c832fb4c02e29c66a9ac3