### PR TITLE
Add Poppler binary check

### DIFF
--- a/Price App/smart_price/config.py
+++ b/Price App/smart_price/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 from pathlib import Path
 
 try:
@@ -33,6 +34,9 @@ _DEFAULT_EXTRACTION_GUIDE = _REPO_ROOT / "extraction_guide.md"
 _DEFAULT_TESSERACT_CMD = Path(r"D:\\Program Files\\Tesseract-OCR\\tesseract.exe")
 _DEFAULT_TESSDATA_PREFIX = Path(r"D:\\Program Files\\Tesseract-OCR\\tessdata")
 _DEFAULT_POPPLER_PATH = Path(__file__).resolve().parents[2] / "poppler" / "bin"
+
+# Logger used for configuration warnings
+logger = logging.getLogger("smart_price")
 
 # Default remote repository for the public demo data
 _DEFAULT_BASE_REPO_URL = (
@@ -105,6 +109,18 @@ __all__ = [
     "RETRY_DELAY_BASE",
     "load_config",
 ]
+
+
+def _check_poppler_bins() -> None:
+    """Verify essential Poppler binaries are present."""
+    required = ["pdftoppm.exe", "pdftocairo.exe", "pdfinfo.exe"]
+    missing = [f for f in required if not (POPPLER_PATH / f).is_file()]
+    if missing:
+        logger.error(
+            "Missing Poppler executables: %s in %s. See README.md 'Poppler setup' section.",
+            ", ".join(missing),
+            POPPLER_PATH,
+        )
 
 
 def load_config() -> None:
@@ -185,6 +201,8 @@ def load_config() -> None:
     LOGO_TOP = os.getenv("LOGO_TOP", config.get("LOGO_TOP", _DEFAULT_LOGO_TOP))
     LOGO_RIGHT = os.getenv("LOGO_RIGHT", config.get("LOGO_RIGHT", _DEFAULT_LOGO_RIGHT))
     LOGO_OPACITY = float(os.getenv("LOGO_OPACITY", config.get("LOGO_OPACITY", _DEFAULT_LOGO_OPACITY)))
+
+    _check_poppler_bins()
 
 
 # Initialise configuration on import

--- a/tests/test_extract_pdf.py
+++ b/tests/test_extract_pdf.py
@@ -1,7 +1,37 @@
+import importlib
+import logging
+import sys
+import types
+import os
+
 from tests.helpers import extract_pdf
+
+import smart_price.config as cfg
 
 
 def test_esmaksn_pdf_threshold():
     df = extract_pdf.parse("tests/samples/ESMAKSAN_2025_MART.pdf")
     assert len(df) >= 1600
     assert df['Malzeme_Kodu'].notna().mean() >= 0.7
+
+
+def test_poppler_missing_warning(monkeypatch, tmp_path, caplog):
+    orig_env = os.environ.get('POPPLER_PATH')
+    dotenv_stub = types.ModuleType('dotenv')
+    dotenv_stub.load_dotenv = lambda *_a, **_k: None
+    dotenv_stub.find_dotenv = lambda *_a, **_k: ''
+    monkeypatch.setitem(sys.modules, 'dotenv', dotenv_stub)
+    monkeypatch.setenv('POPPLER_PATH', str(tmp_path / 'bin'))
+
+    with caplog.at_level(logging.ERROR, logger='smart_price'):
+        importlib.reload(cfg)
+
+    messages = "\n".join(r.getMessage() for r in caplog.records)
+    assert 'poppler' in messages.lower()
+    assert 'readme' in messages.lower()
+
+    if orig_env is None:
+        monkeypatch.delenv('POPPLER_PATH', raising=False)
+    else:
+        monkeypatch.setenv('POPPLER_PATH', orig_env)
+    importlib.reload(cfg)


### PR DESCRIPTION
## Summary
- verify Poppler executables exist when loading config
- log helpful error if the executables are missing
- test warning behaviour in PDF extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6857eed0623c832f8bc03f6699162e76