### PR TITLE
Fix PDF page number handling

### DIFF
--- a/Price App/smart_price/core/extract_pdf.py
+++ b/Price App/smart_price/core/extract_pdf.py
@@ -357,6 +357,11 @@ def extract_from_pdf(
         result["Alt_Baslik"] = None
     if "Sayfa" not in result.columns:
         result["Sayfa"] = 1
+    result["Sayfa"] = (
+        pd.to_numeric(result["Sayfa"], errors="coerce")
+        .fillna(1)
+        .astype(int)
+    )
     result["Record_Code"] = (
         sanitized_base
         + "|"


### PR DESCRIPTION
## Summary
- sanitize page numbers when extracting from PDF
- test that invalid page numbers don't crash extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685819b1c128832fa69059eb07b5ae48